### PR TITLE
DEV-4773 | add pre-commit test related to format, typescript, audit & licenses | fix audit issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn-audit-issues.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+*.json
+*.md
+.cache
+package.json
+package-lock.json
+public

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-    "semi": false,
-    "singleQuote": true,
-    "trailingComma": "es5",
-    "tabWidth": 4
-}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    bracketSpacing: false,
+    jsxBracketSameLine: true,
+    singleQuote: true,
+    trailingComma: 'none',
+    tabWidth: 4,
+    printWidth: 200,
+    semi: true
+}

--- a/audit.sh
+++ b/audit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set +e
+yarn audit
+result=$?
+set -e
+
+if [ "$result" != 0 ]; then
+  if [ -f yarn-audit-known-issues.json ]; then
+    set +e
+    yarn audit --json | grep auditAdvisory > yarn-audit-issues.json
+    set -e
+
+    if diff -q yarn-audit-known-issues.json yarn-audit-issues.json > /dev/null 2>&1; then
+      echo
+      echo Ignorning known vulnerabilities
+      exit 0
+    fi
+  fi
+
+  echo
+  echo Security vulnerabilities were found that were not ignored
+  echo
+  echo Check to see if these vulnerabilities apply to production
+  echo and/or if they have fixes available. If they do not have
+  echo fixes and they do not apply to production, you may ignore them
+  echo
+  echo To ignore these vulnerabilities, run:
+  echo
+  echo "yarn audit --json | grep auditAdvisory > yarn-audit-known-issues.json"
+  echo
+  echo and commit the yarn-audit-known-issues file
+  rm yarn-audit-issues.json
+
+  exit "$result"
+fi

--- a/licenses-summary.txt
+++ b/licenses-summary.txt
@@ -1,0 +1,18 @@
+├─ MIT: 967
+├─ ISC: 50
+├─ CC0-1.0: 41
+├─ Apache-2.0: 29
+├─ BSD-2-Clause: 27
+├─ BSD-3-Clause: 22
+├─ Unlicense: 2
+├─ BlueOak-1.0.0: 2
+├─ Custom: https://reactnative.dev: 1
+├─ MPL-2.0: 1
+├─ CC-BY-4.0: 1
+├─ (Apache-2.0 OR MPL-1.1): 1
+├─ (AFL-2.1 OR BSD-3-Clause): 1
+├─ UNLICENSED: 1
+├─ (BSD-3-Clause OR GPL-2.0): 1
+├─ 0BSD: 1
+└─ (MIT OR CC0-1.0): 1
+

--- a/licenses.txt
+++ b/licenses.txt
@@ -1,0 +1,7706 @@
+├─ @adobe/css-tools@4.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/adobe/css-tools
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@adobe/css-tools
+│  └─ licenseFile: node_modules/@adobe/css-tools/LICENSE
+├─ @alloc/quick-lru@5.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/quick-lru
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@alloc/quick-lru
+│  └─ licenseFile: node_modules/@alloc/quick-lru/license
+├─ @ampproject/remapping@2.3.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/ampproject/remapping
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: jridgewell@google.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@ampproject/remapping
+│  └─ licenseFile: node_modules/@ampproject/remapping/LICENSE
+├─ @babel/code-frame@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/code-frame
+│  └─ licenseFile: node_modules/@babel/code-frame/LICENSE
+├─ @babel/compat-data@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/compat-data
+│  └─ licenseFile: node_modules/@babel/compat-data/LICENSE
+├─ @babel/core@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/core
+│  └─ licenseFile: node_modules/@babel/core/LICENSE
+├─ @babel/eslint-parser@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/eslint-parser
+│  └─ licenseFile: node_modules/@babel/eslint-parser/LICENSE
+├─ @babel/generator@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/generator
+│  └─ licenseFile: node_modules/@babel/generator/LICENSE
+├─ @babel/helper-annotate-as-pure@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-annotate-as-pure
+│  └─ licenseFile: node_modules/@babel/helper-annotate-as-pure/LICENSE
+├─ @babel/helper-builder-binary-assignment-operator-visitor@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-builder-binary-assignment-operator-visitor
+│  └─ licenseFile: node_modules/@babel/helper-builder-binary-assignment-operator-visitor/LICENSE
+├─ @babel/helper-compilation-targets@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-compilation-targets
+│  └─ licenseFile: node_modules/@babel/helper-compilation-targets/LICENSE
+├─ @babel/helper-create-class-features-plugin@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-create-class-features-plugin
+│  └─ licenseFile: node_modules/@babel/helper-create-class-features-plugin/LICENSE
+├─ @babel/helper-create-regexp-features-plugin@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-create-regexp-features-plugin
+│  └─ licenseFile: node_modules/@babel/helper-create-regexp-features-plugin/LICENSE
+├─ @babel/helper-define-polyfill-provider@0.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-polyfills
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-define-polyfill-provider
+│  └─ licenseFile: node_modules/@babel/helper-define-polyfill-provider/LICENSE
+├─ @babel/helper-environment-visitor@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-environment-visitor
+│  └─ licenseFile: node_modules/@babel/helper-environment-visitor/LICENSE
+├─ @babel/helper-function-name@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-function-name
+│  └─ licenseFile: node_modules/@babel/helper-function-name/LICENSE
+├─ @babel/helper-hoist-variables@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-hoist-variables
+│  └─ licenseFile: node_modules/@babel/helper-hoist-variables/LICENSE
+├─ @babel/helper-member-expression-to-functions@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-member-expression-to-functions
+│  └─ licenseFile: node_modules/@babel/helper-member-expression-to-functions/LICENSE
+├─ @babel/helper-module-imports@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-module-imports
+│  └─ licenseFile: node_modules/@babel/helper-module-imports/LICENSE
+├─ @babel/helper-module-transforms@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-module-transforms
+│  └─ licenseFile: node_modules/@babel/helper-module-transforms/LICENSE
+├─ @babel/helper-optimise-call-expression@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-optimise-call-expression
+│  └─ licenseFile: node_modules/@babel/helper-optimise-call-expression/LICENSE
+├─ @babel/helper-plugin-utils@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-plugin-utils
+│  └─ licenseFile: node_modules/@babel/helper-plugin-utils/LICENSE
+├─ @babel/helper-remap-async-to-generator@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-remap-async-to-generator
+│  └─ licenseFile: node_modules/@babel/helper-remap-async-to-generator/LICENSE
+├─ @babel/helper-replace-supers@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-replace-supers
+│  └─ licenseFile: node_modules/@babel/helper-replace-supers/LICENSE
+├─ @babel/helper-simple-access@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-simple-access
+│  └─ licenseFile: node_modules/@babel/helper-simple-access/LICENSE
+├─ @babel/helper-skip-transparent-expression-wrappers@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-skip-transparent-expression-wrappers
+│  └─ licenseFile: node_modules/@babel/helper-skip-transparent-expression-wrappers/LICENSE
+├─ @babel/helper-split-export-declaration@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-split-export-declaration
+│  └─ licenseFile: node_modules/@babel/helper-split-export-declaration/LICENSE
+├─ @babel/helper-string-parser@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-string-parser
+│  └─ licenseFile: node_modules/@babel/helper-string-parser/LICENSE
+├─ @babel/helper-validator-identifier@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-validator-identifier
+│  └─ licenseFile: node_modules/@babel/helper-validator-identifier/LICENSE
+├─ @babel/helper-validator-option@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-validator-option
+│  └─ licenseFile: node_modules/@babel/helper-validator-option/LICENSE
+├─ @babel/helper-wrap-function@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helper-wrap-function
+│  └─ licenseFile: node_modules/@babel/helper-wrap-function/LICENSE
+├─ @babel/helpers@7.27.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/helpers
+│  └─ licenseFile: node_modules/@babel/helpers/LICENSE
+├─ @babel/highlight@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/highlight
+│  └─ licenseFile: node_modules/@babel/highlight/LICENSE
+├─ @babel/parser@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/parser
+│  └─ licenseFile: node_modules/@babel/parser/LICENSE
+├─ @babel/plugin-bugfix-firefox-class-in-computed-class-key@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key
+│  └─ licenseFile: node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key/LICENSE
+├─ @babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression
+│  └─ licenseFile: node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/LICENSE
+├─ @babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining
+│  └─ licenseFile: node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/LICENSE
+├─ @babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly
+│  └─ licenseFile: node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/LICENSE
+├─ @babel/plugin-proposal-class-properties@7.18.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-proposal-class-properties
+│  └─ licenseFile: node_modules/@babel/plugin-proposal-class-properties/LICENSE
+├─ @babel/plugin-proposal-decorators@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-proposal-decorators
+│  └─ licenseFile: node_modules/@babel/plugin-proposal-decorators/LICENSE
+├─ @babel/plugin-proposal-nullish-coalescing-operator@7.18.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-proposal-nullish-coalescing-operator
+│  └─ licenseFile: node_modules/@babel/plugin-proposal-nullish-coalescing-operator/LICENSE
+├─ @babel/plugin-proposal-numeric-separator@7.18.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-proposal-numeric-separator
+│  └─ licenseFile: node_modules/@babel/plugin-proposal-numeric-separator/LICENSE
+├─ @babel/plugin-proposal-optional-chaining@7.21.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-proposal-optional-chaining
+│  └─ licenseFile: node_modules/@babel/plugin-proposal-optional-chaining/LICENSE
+├─ @babel/plugin-proposal-private-methods@7.18.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-proposal-private-methods
+│  └─ licenseFile: node_modules/@babel/plugin-proposal-private-methods/LICENSE
+├─ @babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-plugin-proposal-private-property-in-object
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-proposal-private-property-in-object
+│  └─ licenseFile: node_modules/@babel/plugin-proposal-private-property-in-object/LICENSE
+├─ @babel/plugin-syntax-async-generators@7.8.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-async-generators
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-async-generators
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-async-generators/LICENSE
+├─ @babel/plugin-syntax-bigint@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-bigint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-bigint
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-bigint/LICENSE
+├─ @babel/plugin-syntax-class-properties@7.12.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-class-properties
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-class-properties/LICENSE
+├─ @babel/plugin-syntax-class-static-block@7.14.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-class-static-block
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-class-static-block/LICENSE
+├─ @babel/plugin-syntax-decorators@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-decorators
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-decorators/LICENSE
+├─ @babel/plugin-syntax-dynamic-import@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-dynamic-import
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-dynamic-import
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-dynamic-import/LICENSE
+├─ @babel/plugin-syntax-export-namespace-from@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-export-namespace-from
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-export-namespace-from
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-export-namespace-from/LICENSE
+├─ @babel/plugin-syntax-flow@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-flow
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-flow/LICENSE
+├─ @babel/plugin-syntax-import-assertions@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-import-assertions
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-import-assertions/LICENSE
+├─ @babel/plugin-syntax-import-attributes@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-import-attributes
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-import-attributes/LICENSE
+├─ @babel/plugin-syntax-import-meta@7.10.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-import-meta
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-import-meta/LICENSE
+├─ @babel/plugin-syntax-json-strings@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-json-strings
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-json-strings
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-json-strings/LICENSE
+├─ @babel/plugin-syntax-jsx@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-jsx
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-jsx/LICENSE
+├─ @babel/plugin-syntax-logical-assignment-operators@7.10.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-logical-assignment-operators
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-logical-assignment-operators/LICENSE
+├─ @babel/plugin-syntax-nullish-coalescing-operator@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-nullish-coalescing-operator
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-nullish-coalescing-operator
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-nullish-coalescing-operator/LICENSE
+├─ @babel/plugin-syntax-numeric-separator@7.10.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-numeric-separator
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-numeric-separator/LICENSE
+├─ @babel/plugin-syntax-object-rest-spread@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-object-rest-spread
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-object-rest-spread
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-object-rest-spread/LICENSE
+├─ @babel/plugin-syntax-optional-catch-binding@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-catch-binding
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-optional-catch-binding
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-optional-catch-binding/LICENSE
+├─ @babel/plugin-syntax-optional-chaining@7.8.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel/tree/master/packages/babel-plugin-syntax-optional-chaining
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-optional-chaining
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-optional-chaining/LICENSE
+├─ @babel/plugin-syntax-private-property-in-object@7.14.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-private-property-in-object
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-private-property-in-object/LICENSE
+├─ @babel/plugin-syntax-top-level-await@7.14.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-top-level-await
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-top-level-await/LICENSE
+├─ @babel/plugin-syntax-typescript@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-typescript
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-typescript/LICENSE
+├─ @babel/plugin-syntax-unicode-sets-regex@7.18.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-syntax-unicode-sets-regex
+│  └─ licenseFile: node_modules/@babel/plugin-syntax-unicode-sets-regex/LICENSE
+├─ @babel/plugin-transform-arrow-functions@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-arrow-functions
+│  └─ licenseFile: node_modules/@babel/plugin-transform-arrow-functions/LICENSE
+├─ @babel/plugin-transform-async-generator-functions@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-async-generator-functions
+│  └─ licenseFile: node_modules/@babel/plugin-transform-async-generator-functions/LICENSE
+├─ @babel/plugin-transform-async-to-generator@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-async-to-generator
+│  └─ licenseFile: node_modules/@babel/plugin-transform-async-to-generator/LICENSE
+├─ @babel/plugin-transform-block-scoped-functions@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-block-scoped-functions
+│  └─ licenseFile: node_modules/@babel/plugin-transform-block-scoped-functions/LICENSE
+├─ @babel/plugin-transform-block-scoping@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-block-scoping
+│  └─ licenseFile: node_modules/@babel/plugin-transform-block-scoping/LICENSE
+├─ @babel/plugin-transform-class-properties@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-class-properties
+│  └─ licenseFile: node_modules/@babel/plugin-transform-class-properties/LICENSE
+├─ @babel/plugin-transform-class-static-block@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-class-static-block
+│  └─ licenseFile: node_modules/@babel/plugin-transform-class-static-block/LICENSE
+├─ @babel/plugin-transform-classes@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-classes
+│  └─ licenseFile: node_modules/@babel/plugin-transform-classes/LICENSE
+├─ @babel/plugin-transform-computed-properties@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-computed-properties
+│  └─ licenseFile: node_modules/@babel/plugin-transform-computed-properties/LICENSE
+├─ @babel/plugin-transform-destructuring@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-destructuring
+│  └─ licenseFile: node_modules/@babel/plugin-transform-destructuring/LICENSE
+├─ @babel/plugin-transform-dotall-regex@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-dotall-regex
+│  └─ licenseFile: node_modules/@babel/plugin-transform-dotall-regex/LICENSE
+├─ @babel/plugin-transform-duplicate-keys@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-duplicate-keys
+│  └─ licenseFile: node_modules/@babel/plugin-transform-duplicate-keys/LICENSE
+├─ @babel/plugin-transform-dynamic-import@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-dynamic-import
+│  └─ licenseFile: node_modules/@babel/plugin-transform-dynamic-import/LICENSE
+├─ @babel/plugin-transform-exponentiation-operator@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-exponentiation-operator
+│  └─ licenseFile: node_modules/@babel/plugin-transform-exponentiation-operator/LICENSE
+├─ @babel/plugin-transform-export-namespace-from@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-export-namespace-from
+│  └─ licenseFile: node_modules/@babel/plugin-transform-export-namespace-from/LICENSE
+├─ @babel/plugin-transform-flow-strip-types@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-flow-strip-types
+│  └─ licenseFile: node_modules/@babel/plugin-transform-flow-strip-types/LICENSE
+├─ @babel/plugin-transform-for-of@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-for-of
+│  └─ licenseFile: node_modules/@babel/plugin-transform-for-of/LICENSE
+├─ @babel/plugin-transform-function-name@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-function-name
+│  └─ licenseFile: node_modules/@babel/plugin-transform-function-name/LICENSE
+├─ @babel/plugin-transform-json-strings@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-json-strings
+│  └─ licenseFile: node_modules/@babel/plugin-transform-json-strings/LICENSE
+├─ @babel/plugin-transform-literals@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-literals
+│  └─ licenseFile: node_modules/@babel/plugin-transform-literals/LICENSE
+├─ @babel/plugin-transform-logical-assignment-operators@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-logical-assignment-operators
+│  └─ licenseFile: node_modules/@babel/plugin-transform-logical-assignment-operators/LICENSE
+├─ @babel/plugin-transform-member-expression-literals@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-member-expression-literals
+│  └─ licenseFile: node_modules/@babel/plugin-transform-member-expression-literals/LICENSE
+├─ @babel/plugin-transform-modules-amd@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-modules-amd
+│  └─ licenseFile: node_modules/@babel/plugin-transform-modules-amd/LICENSE
+├─ @babel/plugin-transform-modules-commonjs@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-modules-commonjs
+│  └─ licenseFile: node_modules/@babel/plugin-transform-modules-commonjs/LICENSE
+├─ @babel/plugin-transform-modules-systemjs@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-modules-systemjs
+│  └─ licenseFile: node_modules/@babel/plugin-transform-modules-systemjs/LICENSE
+├─ @babel/plugin-transform-modules-umd@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-modules-umd
+│  └─ licenseFile: node_modules/@babel/plugin-transform-modules-umd/LICENSE
+├─ @babel/plugin-transform-named-capturing-groups-regex@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-named-capturing-groups-regex
+│  └─ licenseFile: node_modules/@babel/plugin-transform-named-capturing-groups-regex/LICENSE
+├─ @babel/plugin-transform-new-target@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-new-target
+│  └─ licenseFile: node_modules/@babel/plugin-transform-new-target/LICENSE
+├─ @babel/plugin-transform-nullish-coalescing-operator@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-nullish-coalescing-operator
+│  └─ licenseFile: node_modules/@babel/plugin-transform-nullish-coalescing-operator/LICENSE
+├─ @babel/plugin-transform-numeric-separator@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-numeric-separator
+│  └─ licenseFile: node_modules/@babel/plugin-transform-numeric-separator/LICENSE
+├─ @babel/plugin-transform-object-rest-spread@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-object-rest-spread
+│  └─ licenseFile: node_modules/@babel/plugin-transform-object-rest-spread/LICENSE
+├─ @babel/plugin-transform-object-super@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-object-super
+│  └─ licenseFile: node_modules/@babel/plugin-transform-object-super/LICENSE
+├─ @babel/plugin-transform-optional-catch-binding@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-optional-catch-binding
+│  └─ licenseFile: node_modules/@babel/plugin-transform-optional-catch-binding/LICENSE
+├─ @babel/plugin-transform-optional-chaining@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-optional-chaining
+│  └─ licenseFile: node_modules/@babel/plugin-transform-optional-chaining/LICENSE
+├─ @babel/plugin-transform-parameters@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-parameters
+│  └─ licenseFile: node_modules/@babel/plugin-transform-parameters/LICENSE
+├─ @babel/plugin-transform-private-methods@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-private-methods
+│  └─ licenseFile: node_modules/@babel/plugin-transform-private-methods/LICENSE
+├─ @babel/plugin-transform-private-property-in-object@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-private-property-in-object
+│  └─ licenseFile: node_modules/@babel/plugin-transform-private-property-in-object/LICENSE
+├─ @babel/plugin-transform-property-literals@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-property-literals
+│  └─ licenseFile: node_modules/@babel/plugin-transform-property-literals/LICENSE
+├─ @babel/plugin-transform-react-constant-elements@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-react-constant-elements
+│  └─ licenseFile: node_modules/@babel/plugin-transform-react-constant-elements/LICENSE
+├─ @babel/plugin-transform-react-display-name@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-react-display-name
+│  └─ licenseFile: node_modules/@babel/plugin-transform-react-display-name/LICENSE
+├─ @babel/plugin-transform-react-jsx-development@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-react-jsx-development
+│  └─ licenseFile: node_modules/@babel/plugin-transform-react-jsx-development/LICENSE
+├─ @babel/plugin-transform-react-jsx@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-react-jsx
+│  └─ licenseFile: node_modules/@babel/plugin-transform-react-jsx/LICENSE
+├─ @babel/plugin-transform-react-pure-annotations@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-react-pure-annotations
+│  └─ licenseFile: node_modules/@babel/plugin-transform-react-pure-annotations/LICENSE
+├─ @babel/plugin-transform-regenerator@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-regenerator
+│  └─ licenseFile: node_modules/@babel/plugin-transform-regenerator/LICENSE
+├─ @babel/plugin-transform-reserved-words@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-reserved-words
+│  └─ licenseFile: node_modules/@babel/plugin-transform-reserved-words/LICENSE
+├─ @babel/plugin-transform-runtime@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-runtime
+│  └─ licenseFile: node_modules/@babel/plugin-transform-runtime/LICENSE
+├─ @babel/plugin-transform-shorthand-properties@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-shorthand-properties
+│  └─ licenseFile: node_modules/@babel/plugin-transform-shorthand-properties/LICENSE
+├─ @babel/plugin-transform-spread@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-spread
+│  └─ licenseFile: node_modules/@babel/plugin-transform-spread/LICENSE
+├─ @babel/plugin-transform-sticky-regex@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-sticky-regex
+│  └─ licenseFile: node_modules/@babel/plugin-transform-sticky-regex/LICENSE
+├─ @babel/plugin-transform-template-literals@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-template-literals
+│  └─ licenseFile: node_modules/@babel/plugin-transform-template-literals/LICENSE
+├─ @babel/plugin-transform-typeof-symbol@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-typeof-symbol
+│  └─ licenseFile: node_modules/@babel/plugin-transform-typeof-symbol/LICENSE
+├─ @babel/plugin-transform-typescript@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-typescript
+│  └─ licenseFile: node_modules/@babel/plugin-transform-typescript/LICENSE
+├─ @babel/plugin-transform-unicode-escapes@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-unicode-escapes
+│  └─ licenseFile: node_modules/@babel/plugin-transform-unicode-escapes/LICENSE
+├─ @babel/plugin-transform-unicode-property-regex@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-unicode-property-regex
+│  └─ licenseFile: node_modules/@babel/plugin-transform-unicode-property-regex/LICENSE
+├─ @babel/plugin-transform-unicode-regex@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-unicode-regex
+│  └─ licenseFile: node_modules/@babel/plugin-transform-unicode-regex/LICENSE
+├─ @babel/plugin-transform-unicode-sets-regex@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/plugin-transform-unicode-sets-regex
+│  └─ licenseFile: node_modules/@babel/plugin-transform-unicode-sets-regex/LICENSE
+├─ @babel/preset-env@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/preset-env
+│  └─ licenseFile: node_modules/@babel/preset-env/LICENSE
+├─ @babel/preset-modules@0.1.6-no-external-plugins
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/preset-modules
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/preset-modules
+│  └─ licenseFile: node_modules/@babel/preset-modules/LICENSE
+├─ @babel/preset-react@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/preset-react
+│  └─ licenseFile: node_modules/@babel/preset-react/LICENSE
+├─ @babel/preset-typescript@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/preset-typescript
+│  └─ licenseFile: node_modules/@babel/preset-typescript/LICENSE
+├─ @babel/regjsgen@0.8.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bnjmnt4n/regjsgen
+│  ├─ publisher: Benjamin Tan
+│  ├─ url: https://ofcr.se/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/regjsgen
+│  └─ licenseFile: node_modules/@babel/regjsgen/LICENSE-MIT.txt
+├─ @babel/runtime@7.27.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/runtime
+│  └─ licenseFile: node_modules/@babel/runtime/LICENSE
+├─ @babel/template@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/template
+│  └─ licenseFile: node_modules/@babel/template/LICENSE
+├─ @babel/traverse@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/traverse
+│  └─ licenseFile: node_modules/@babel/traverse/LICENSE
+├─ @babel/types@7.24.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel
+│  ├─ publisher: The Babel Team
+│  ├─ url: https://babel.dev/team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@babel/types
+│  └─ licenseFile: node_modules/@babel/types/LICENSE
+├─ @bcoe/v8-coverage@0.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/demurgos/v8-coverage
+│  ├─ publisher: Charles Samborski
+│  ├─ email: demurgos@demurgos.net
+│  ├─ url: https://demurgos.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@bcoe/v8-coverage
+│  └─ licenseFile: node_modules/@bcoe/v8-coverage/LICENSE.md
+├─ @csstools/normalize.css@12.1.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/normalize.css
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/normalize.css
+│  └─ licenseFile: node_modules/@csstools/normalize.css/LICENSE.md
+├─ @csstools/postcss-cascade-layers@1.1.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-cascade-layers
+│  └─ licenseFile: node_modules/@csstools/postcss-cascade-layers/LICENSE.md
+├─ @csstools/postcss-color-function@1.1.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-color-function
+│  └─ licenseFile: node_modules/@csstools/postcss-color-function/LICENSE.md
+├─ @csstools/postcss-font-format-keywords@1.0.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-font-format-keywords
+│  └─ licenseFile: node_modules/@csstools/postcss-font-format-keywords/LICENSE.md
+├─ @csstools/postcss-hwb-function@1.0.2
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-hwb-function
+│  └─ licenseFile: node_modules/@csstools/postcss-hwb-function/LICENSE.md
+├─ @csstools/postcss-ic-unit@1.0.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-ic-unit
+│  └─ licenseFile: node_modules/@csstools/postcss-ic-unit/LICENSE.md
+├─ @csstools/postcss-is-pseudo-class@2.0.7
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-is-pseudo-class
+│  └─ licenseFile: node_modules/@csstools/postcss-is-pseudo-class/LICENSE.md
+├─ @csstools/postcss-nested-calc@1.0.0
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-nested-calc
+│  └─ licenseFile: node_modules/@csstools/postcss-nested-calc/LICENSE.md
+├─ @csstools/postcss-normalize-display-values@1.0.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-normalize-display-values
+│  └─ licenseFile: node_modules/@csstools/postcss-normalize-display-values/LICENSE.md
+├─ @csstools/postcss-oklab-function@1.1.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-oklab-function
+│  └─ licenseFile: node_modules/@csstools/postcss-oklab-function/LICENSE.md
+├─ @csstools/postcss-progressive-custom-properties@1.3.0
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-progressive-custom-properties
+│  └─ licenseFile: node_modules/@csstools/postcss-progressive-custom-properties/LICENSE.md
+├─ @csstools/postcss-stepped-value-functions@1.0.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-stepped-value-functions
+│  └─ licenseFile: node_modules/@csstools/postcss-stepped-value-functions/LICENSE.md
+├─ @csstools/postcss-text-decoration-shorthand@1.0.0
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-text-decoration-shorthand
+│  └─ licenseFile: node_modules/@csstools/postcss-text-decoration-shorthand/LICENSE.md
+├─ @csstools/postcss-trigonometric-functions@1.0.2
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-trigonometric-functions
+│  └─ licenseFile: node_modules/@csstools/postcss-trigonometric-functions/LICENSE.md
+├─ @csstools/postcss-unset-value@1.0.2
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/postcss-unset-value
+│  └─ licenseFile: node_modules/@csstools/postcss-unset-value/LICENSE.md
+├─ @csstools/selector-specificity@2.2.0
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@csstools/selector-specificity
+│  └─ licenseFile: node_modules/@csstools/selector-specificity/LICENSE.md
+├─ @eslint-community/eslint-utils@4.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eslint-community/eslint-utils
+│  ├─ publisher: Toru Nagashima
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@eslint-community/eslint-utils
+│  └─ licenseFile: node_modules/@eslint-community/eslint-utils/LICENSE
+├─ @eslint-community/regexpp@4.10.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eslint-community/regexpp
+│  ├─ publisher: Toru Nagashima
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@eslint-community/regexpp
+│  └─ licenseFile: node_modules/@eslint-community/regexpp/LICENSE
+├─ @eslint/eslintrc@2.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eslint/eslintrc
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@eslint/eslintrc
+│  └─ licenseFile: node_modules/@eslint/eslintrc/LICENSE
+├─ @eslint/js@8.57.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eslint/eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@eslint/js
+│  └─ licenseFile: node_modules/@eslint/js/LICENSE
+├─ @fontsource/roboto@5.0.13
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/fontsource/font-files
+│  ├─ publisher: Google Inc.
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@fontsource/roboto
+│  └─ licenseFile: node_modules/@fontsource/roboto/LICENSE
+├─ @gataca/design-system@0.4.15
+│  ├─ licenses: Custom: https://reactnative.dev
+│  ├─ publisher: Gataca
+│  ├─ email: it@gataca.io
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@gataca/design-system
+│  └─ licenseFile: node_modules/@gataca/design-system/README.md
+├─ @humanwhocodes/config-array@0.11.14
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/humanwhocodes/config-array
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@humanwhocodes/config-array
+│  └─ licenseFile: node_modules/@humanwhocodes/config-array/LICENSE
+├─ @humanwhocodes/module-importer@1.0.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/humanwhocodes/module-importer
+│  ├─ publisher: Nicholas C. Zaks
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@humanwhocodes/module-importer
+│  └─ licenseFile: node_modules/@humanwhocodes/module-importer/LICENSE
+├─ @humanwhocodes/object-schema@2.0.3
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/humanwhocodes/object-schema
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@humanwhocodes/object-schema
+│  └─ licenseFile: node_modules/@humanwhocodes/object-schema/LICENSE
+├─ @isaacs/cliui@8.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/cliui
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@isaacs/cliui
+│  └─ licenseFile: node_modules/@isaacs/cliui/LICENSE.txt
+├─ @istanbuljs/load-nyc-config@1.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/istanbuljs/load-nyc-config
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@istanbuljs/load-nyc-config
+│  └─ licenseFile: node_modules/@istanbuljs/load-nyc-config/LICENSE
+├─ @istanbuljs/schema@0.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/istanbuljs/schema
+│  ├─ publisher: Corey Farrell
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@istanbuljs/schema
+│  └─ licenseFile: node_modules/@istanbuljs/schema/LICENSE
+├─ @jest/console@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/console
+│  └─ licenseFile: node_modules/@jest/console/LICENSE
+├─ @jest/core@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/core
+│  └─ licenseFile: node_modules/@jest/core/LICENSE
+├─ @jest/environment@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/environment
+│  └─ licenseFile: node_modules/@jest/environment/LICENSE
+├─ @jest/expect-utils@29.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jestjs/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/expect-utils
+│  └─ licenseFile: node_modules/@jest/expect-utils/LICENSE
+├─ @jest/fake-timers@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/fake-timers
+│  └─ licenseFile: node_modules/@jest/fake-timers/LICENSE
+├─ @jest/globals@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/globals
+│  └─ licenseFile: node_modules/@jest/globals/LICENSE
+├─ @jest/reporters@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/reporters
+│  └─ licenseFile: node_modules/@jest/reporters/LICENSE
+├─ @jest/schemas@28.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/schemas
+│  └─ licenseFile: node_modules/@jest/schemas/LICENSE
+├─ @jest/source-map@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/source-map
+│  └─ licenseFile: node_modules/@jest/source-map/LICENSE
+├─ @jest/test-result@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/test-result
+│  └─ licenseFile: node_modules/@jest/test-result/LICENSE
+├─ @jest/test-sequencer@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/test-sequencer
+│  └─ licenseFile: node_modules/@jest/test-sequencer/LICENSE
+├─ @jest/transform@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/transform
+│  └─ licenseFile: node_modules/@jest/transform/LICENSE
+├─ @jest/types@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jest/types
+│  └─ licenseFile: node_modules/@jest/types/LICENSE
+├─ @jridgewell/gen-mapping@0.3.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/gen-mapping
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jridgewell/gen-mapping
+│  └─ licenseFile: node_modules/@jridgewell/gen-mapping/LICENSE
+├─ @jridgewell/resolve-uri@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/resolve-uri
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jridgewell/resolve-uri
+│  └─ licenseFile: node_modules/@jridgewell/resolve-uri/LICENSE
+├─ @jridgewell/set-array@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/set-array
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jridgewell/set-array
+│  └─ licenseFile: node_modules/@jridgewell/set-array/LICENSE
+├─ @jridgewell/source-map@0.3.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/source-map
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jridgewell/source-map
+│  └─ licenseFile: node_modules/@jridgewell/source-map/LICENSE
+├─ @jridgewell/sourcemap-codec@1.4.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/sourcemap-codec
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jridgewell/sourcemap-codec
+│  └─ licenseFile: node_modules/@jridgewell/sourcemap-codec/LICENSE
+├─ @jridgewell/trace-mapping@0.3.25
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jridgewell/trace-mapping
+│  ├─ publisher: Justin Ridgewell
+│  ├─ email: justin@ridgewell.name
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@jridgewell/trace-mapping
+│  └─ licenseFile: node_modules/@jridgewell/trace-mapping/LICENSE
+├─ @leichtgewicht/ip-codec@2.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/martinheidegger/ip-codec
+│  ├─ publisher: Martin Heidegger
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@leichtgewicht/ip-codec
+│  └─ licenseFile: node_modules/@leichtgewicht/ip-codec/LICENSE
+├─ @nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1
+│  ├─ licenses: MIT
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@nicolo-ribaudo/eslint-scope-5-internals
+│  └─ licenseFile: node_modules/@nicolo-ribaudo/eslint-scope-5-internals/LICENSE
+├─ @nodelib/fs.scandir@2.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.scandir
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@nodelib/fs.scandir
+│  └─ licenseFile: node_modules/@nodelib/fs.scandir/LICENSE
+├─ @nodelib/fs.stat@2.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.stat
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@nodelib/fs.stat
+│  └─ licenseFile: node_modules/@nodelib/fs.stat/LICENSE
+├─ @nodelib/fs.walk@1.2.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodelib/nodelib/tree/master/packages/fs/fs.walk
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@nodelib/fs.walk
+│  └─ licenseFile: node_modules/@nodelib/fs.walk/LICENSE
+├─ @pkgjs/parseargs@0.11.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pkgjs/parseargs
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@pkgjs/parseargs
+│  └─ licenseFile: node_modules/@pkgjs/parseargs/LICENSE
+├─ @pmmmwh/react-refresh-webpack-plugin@0.5.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pmmmwh/react-refresh-webpack-plugin
+│  ├─ publisher: Michael Mok
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@pmmmwh/react-refresh-webpack-plugin
+│  └─ licenseFile: node_modules/@pmmmwh/react-refresh-webpack-plugin/LICENSE
+├─ @rollup/plugin-babel@5.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rollup/plugins
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@rollup/plugin-babel
+│  └─ licenseFile: node_modules/@rollup/plugin-babel/LICENSE
+├─ @rollup/plugin-node-resolve@11.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rollup/plugins
+│  ├─ publisher: Rich Harris
+│  ├─ email: richard.a.harris@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@rollup/plugin-node-resolve
+│  └─ licenseFile: node_modules/@rollup/plugin-node-resolve/LICENSE
+├─ @rollup/plugin-replace@2.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rollup/plugins
+│  ├─ publisher: Rich Harris
+│  ├─ email: richard.a.harris@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@rollup/plugin-replace
+│  └─ licenseFile: node_modules/@rollup/plugin-replace/LICENSE
+├─ @rollup/pluginutils@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rollup/plugins
+│  ├─ publisher: Rich Harris
+│  ├─ email: richard.a.harris@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@rollup/pluginutils
+│  └─ licenseFile: node_modules/@rollup/pluginutils/LICENSE
+├─ @rushstack/eslint-patch@1.10.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/microsoft/rushstack
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@rushstack/eslint-patch
+│  └─ licenseFile: node_modules/@rushstack/eslint-patch/LICENSE
+├─ @sinclair/typebox@0.24.51
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sinclairzx81/typebox
+│  ├─ publisher: sinclairzx81
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@sinclair/typebox
+│  └─ licenseFile: node_modules/@sinclair/typebox/license
+├─ @sinonjs/commons@1.8.6
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/sinonjs/commons
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@sinonjs/commons
+│  └─ licenseFile: node_modules/@sinonjs/commons/LICENSE
+├─ @sinonjs/fake-timers@8.1.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/sinonjs/fake-timers
+│  ├─ publisher: Christian Johansen
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@sinonjs/fake-timers
+│  └─ licenseFile: node_modules/@sinonjs/fake-timers/LICENSE
+├─ @surma/rollup-plugin-off-main-thread@2.2.3
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/surma/rollup-plugin-off-main-thread
+│  ├─ publisher: Surma
+│  ├─ email: surma@google.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@surma/rollup-plugin-off-main-thread
+│  └─ licenseFile: node_modules/@surma/rollup-plugin-off-main-thread/LICENSE
+├─ @svgr/babel-plugin-add-jsx-attribute@5.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-add-jsx-attribute
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-plugin-add-jsx-attribute
+│  └─ licenseFile: node_modules/@svgr/babel-plugin-add-jsx-attribute/LICENSE
+├─ @svgr/babel-plugin-remove-jsx-attribute@5.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-remove-jsx-attribute
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-plugin-remove-jsx-attribute
+│  └─ licenseFile: node_modules/@svgr/babel-plugin-remove-jsx-attribute/LICENSE
+├─ @svgr/babel-plugin-remove-jsx-empty-expression@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-remove-jsx-empty-expression
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-plugin-remove-jsx-empty-expression
+│  └─ licenseFile: node_modules/@svgr/babel-plugin-remove-jsx-empty-expression/LICENSE
+├─ @svgr/babel-plugin-replace-jsx-attribute-value@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-replace-jsx-attribute-value
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-plugin-replace-jsx-attribute-value
+│  └─ licenseFile: node_modules/@svgr/babel-plugin-replace-jsx-attribute-value/LICENSE
+├─ @svgr/babel-plugin-svg-dynamic-title@5.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-svg-dynamic-title
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-plugin-svg-dynamic-title
+│  └─ licenseFile: node_modules/@svgr/babel-plugin-svg-dynamic-title/LICENSE
+├─ @svgr/babel-plugin-svg-em-dimensions@5.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-svg-em-dimensions
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-plugin-svg-em-dimensions
+│  └─ licenseFile: node_modules/@svgr/babel-plugin-svg-em-dimensions/LICENSE
+├─ @svgr/babel-plugin-transform-react-native-svg@5.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-transform-react-native-svg
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-plugin-transform-react-native-svg
+│  └─ licenseFile: node_modules/@svgr/babel-plugin-transform-react-native-svg/LICENSE
+├─ @svgr/babel-plugin-transform-svg-component@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-plugin-transform-svg-component
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-plugin-transform-svg-component
+│  └─ licenseFile: node_modules/@svgr/babel-plugin-transform-svg-component/LICENSE
+├─ @svgr/babel-preset@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/babel-preset
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/babel-preset
+│  └─ licenseFile: node_modules/@svgr/babel-preset/LICENSE
+├─ @svgr/core@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/core
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/core
+│  └─ licenseFile: node_modules/@svgr/core/LICENSE
+├─ @svgr/hast-util-to-babel-ast@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/hast-util-to-babel-ast
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/hast-util-to-babel-ast
+│  └─ licenseFile: node_modules/@svgr/hast-util-to-babel-ast/LICENSE
+├─ @svgr/plugin-jsx@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/plugin-jsx
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/plugin-jsx
+│  └─ licenseFile: node_modules/@svgr/plugin-jsx/LICENSE
+├─ @svgr/plugin-svgo@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/plugin-svgo
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/plugin-svgo
+│  └─ licenseFile: node_modules/@svgr/plugin-svgo/LICENSE
+├─ @svgr/webpack@5.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gregberge/svgr/tree/master/packages/webpack
+│  ├─ publisher: Greg Bergé
+│  ├─ email: berge.greg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@svgr/webpack
+│  └─ licenseFile: node_modules/@svgr/webpack/LICENSE
+├─ @testing-library/dom@8.20.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/testing-library/dom-testing-library
+│  ├─ publisher: Kent C. Dodds
+│  ├─ email: me@kentcdodds.com
+│  ├─ url: https://kentcdodds.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@testing-library/dom
+│  └─ licenseFile: node_modules/@testing-library/dom/LICENSE
+├─ @testing-library/jest-dom@5.17.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/testing-library/jest-dom
+│  ├─ publisher: Ernesto Garcia
+│  ├─ email: gnapse@gmail.com
+│  ├─ url: http://gnapse.github.io
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@testing-library/jest-dom
+│  └─ licenseFile: node_modules/@testing-library/jest-dom/LICENSE
+├─ @testing-library/react@13.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/testing-library/react-testing-library
+│  ├─ publisher: Kent C. Dodds
+│  ├─ email: me@kentcdodds.com
+│  ├─ url: https://kentcdodds.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@testing-library/react
+│  └─ licenseFile: node_modules/@testing-library/react/LICENSE
+├─ @testing-library/user-event@13.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/testing-library/user-event
+│  ├─ publisher: Giorgio Polvara
+│  ├─ email: polvara@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@testing-library/user-event
+│  └─ licenseFile: node_modules/@testing-library/user-event/LICENSE
+├─ @tootallnate/once@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/once
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  └─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@tootallnate/once
+├─ @trysound/sax@0.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/svg/sax
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@trysound/sax
+│  └─ licenseFile: node_modules/@trysound/sax/LICENSE
+├─ @types/aria-query@5.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/aria-query
+│  └─ licenseFile: node_modules/@types/aria-query/LICENSE
+├─ @types/babel__core@7.20.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/babel__core
+│  └─ licenseFile: node_modules/@types/babel__core/LICENSE
+├─ @types/babel__generator@7.6.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/babel__generator
+│  └─ licenseFile: node_modules/@types/babel__generator/LICENSE
+├─ @types/babel__template@7.4.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/babel__template
+│  └─ licenseFile: node_modules/@types/babel__template/LICENSE
+├─ @types/babel__traverse@7.20.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/babel__traverse
+│  └─ licenseFile: node_modules/@types/babel__traverse/LICENSE
+├─ @types/body-parser@1.19.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/body-parser
+│  └─ licenseFile: node_modules/@types/body-parser/LICENSE
+├─ @types/bonjour@3.5.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/bonjour
+│  └─ licenseFile: node_modules/@types/bonjour/LICENSE
+├─ @types/connect-history-api-fallback@1.5.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/connect-history-api-fallback
+│  └─ licenseFile: node_modules/@types/connect-history-api-fallback/LICENSE
+├─ @types/connect@3.4.38
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/connect
+│  └─ licenseFile: node_modules/@types/connect/LICENSE
+├─ @types/cookie@0.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/cookie
+│  └─ licenseFile: node_modules/@types/cookie/LICENSE
+├─ @types/eslint@8.56.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/eslint
+│  └─ licenseFile: node_modules/@types/eslint/LICENSE
+├─ @types/estree@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/estree
+│  └─ licenseFile: node_modules/@types/estree/LICENSE
+├─ @types/express-serve-static-core@4.19.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/express-serve-static-core
+│  └─ licenseFile: node_modules/@types/express-serve-static-core/LICENSE
+├─ @types/express@4.17.21
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/express
+│  └─ licenseFile: node_modules/@types/express/LICENSE
+├─ @types/graceful-fs@4.1.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/graceful-fs
+│  └─ licenseFile: node_modules/@types/graceful-fs/LICENSE
+├─ @types/html-minifier-terser@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/html-minifier-terser
+│  └─ licenseFile: node_modules/@types/html-minifier-terser/LICENSE
+├─ @types/http-errors@2.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/http-errors
+│  └─ licenseFile: node_modules/@types/http-errors/LICENSE
+├─ @types/http-proxy@1.17.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/http-proxy
+│  └─ licenseFile: node_modules/@types/http-proxy/LICENSE
+├─ @types/istanbul-lib-coverage@2.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/istanbul-lib-coverage
+│  └─ licenseFile: node_modules/@types/istanbul-lib-coverage/LICENSE
+├─ @types/istanbul-lib-report@3.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/istanbul-lib-report
+│  └─ licenseFile: node_modules/@types/istanbul-lib-report/LICENSE
+├─ @types/istanbul-reports@3.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/istanbul-reports
+│  └─ licenseFile: node_modules/@types/istanbul-reports/LICENSE
+├─ @types/jest@27.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/jest
+│  └─ licenseFile: node_modules/@types/jest/LICENSE
+├─ @types/json-schema@7.0.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/json-schema
+│  └─ licenseFile: node_modules/@types/json-schema/LICENSE
+├─ @types/json5@0.0.29
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ publisher: Jason Swearingen
+│  ├─ email: https://jasonswearingen.github.io
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/json5
+│  └─ licenseFile: node_modules/@types/json5/README.md
+├─ @types/mime@1.3.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/mime
+│  └─ licenseFile: node_modules/@types/mime/LICENSE
+├─ @types/node-forge@1.3.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/node-forge
+│  └─ licenseFile: node_modules/@types/node-forge/LICENSE
+├─ @types/node@16.18.99
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/node
+│  └─ licenseFile: node_modules/@types/node/LICENSE
+├─ @types/parse-json@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/parse-json
+│  └─ licenseFile: node_modules/@types/parse-json/LICENSE
+├─ @types/prettier@2.7.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/prettier
+│  └─ licenseFile: node_modules/@types/prettier/LICENSE
+├─ @types/prop-types@15.7.12
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/prop-types
+│  └─ licenseFile: node_modules/@types/prop-types/LICENSE
+├─ @types/q@1.5.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/q
+│  └─ licenseFile: node_modules/@types/q/LICENSE
+├─ @types/qs@6.9.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/qs
+│  └─ licenseFile: node_modules/@types/qs/LICENSE
+├─ @types/range-parser@1.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/range-parser
+│  └─ licenseFile: node_modules/@types/range-parser/LICENSE
+├─ @types/react-dom@18.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/react-dom
+│  └─ licenseFile: node_modules/@types/react-dom/LICENSE
+├─ @types/react-i18next@8.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/i18next/react-i18next
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/react-i18next
+│  └─ licenseFile: node_modules/@types/react-i18next/LICENSE
+├─ @types/react@18.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/react
+│  └─ licenseFile: node_modules/@types/react/LICENSE
+├─ @types/resolve@1.17.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/resolve
+│  └─ licenseFile: node_modules/@types/resolve/LICENSE
+├─ @types/retry@0.12.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/retry
+│  └─ licenseFile: node_modules/@types/retry/LICENSE
+├─ @types/semver@7.5.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/semver
+│  └─ licenseFile: node_modules/@types/semver/LICENSE
+├─ @types/send@0.17.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/send
+│  └─ licenseFile: node_modules/@types/send/LICENSE
+├─ @types/serve-index@1.9.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/serve-index
+│  └─ licenseFile: node_modules/@types/serve-index/LICENSE
+├─ @types/serve-static@1.15.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/serve-static
+│  └─ licenseFile: node_modules/@types/serve-static/LICENSE
+├─ @types/sockjs@0.3.36
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/sockjs
+│  └─ licenseFile: node_modules/@types/sockjs/LICENSE
+├─ @types/stack-utils@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/stack-utils
+│  └─ licenseFile: node_modules/@types/stack-utils/LICENSE
+├─ @types/testing-library__jest-dom@5.14.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/testing-library__jest-dom
+│  └─ licenseFile: node_modules/@types/testing-library__jest-dom/LICENSE
+├─ @types/trusted-types@2.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/trusted-types
+│  └─ licenseFile: node_modules/@types/trusted-types/LICENSE
+├─ @types/ws@8.5.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/ws
+│  └─ licenseFile: node_modules/@types/ws/LICENSE
+├─ @types/yargs-parser@21.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/yargs-parser
+│  └─ licenseFile: node_modules/@types/yargs-parser/LICENSE
+├─ @types/yargs@17.0.32
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/DefinitelyTyped/DefinitelyTyped
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@types/yargs
+│  └─ licenseFile: node_modules/@types/yargs/LICENSE
+├─ @typescript-eslint/eslint-plugin@5.62.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/eslint-plugin
+│  └─ licenseFile: node_modules/@typescript-eslint/eslint-plugin/LICENSE
+├─ @typescript-eslint/experimental-utils@5.62.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/experimental-utils
+│  └─ licenseFile: node_modules/@typescript-eslint/experimental-utils/LICENSE
+├─ @typescript-eslint/parser@5.62.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/parser
+│  └─ licenseFile: node_modules/@typescript-eslint/parser/LICENSE
+├─ @typescript-eslint/scope-manager@5.62.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/scope-manager
+│  └─ licenseFile: node_modules/@typescript-eslint/scope-manager/LICENSE
+├─ @typescript-eslint/type-utils@5.62.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/type-utils
+│  └─ licenseFile: node_modules/@typescript-eslint/type-utils/LICENSE
+├─ @typescript-eslint/types@5.62.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/types
+│  └─ licenseFile: node_modules/@typescript-eslint/types/LICENSE
+├─ @typescript-eslint/typescript-estree@5.62.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/typescript-estree
+│  └─ licenseFile: node_modules/@typescript-eslint/typescript-estree/LICENSE
+├─ @typescript-eslint/utils@5.62.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/utils
+│  └─ licenseFile: node_modules/@typescript-eslint/utils/LICENSE
+├─ @typescript-eslint/visitor-keys@5.62.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/typescript-eslint/typescript-eslint
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@typescript-eslint/visitor-keys
+│  └─ licenseFile: node_modules/@typescript-eslint/visitor-keys/LICENSE
+├─ @ungap/structured-clone@1.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/ungap/structured-clone
+│  ├─ publisher: Andrea Giammarchi
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@ungap/structured-clone
+│  └─ licenseFile: node_modules/@ungap/structured-clone/LICENSE
+├─ @webassemblyjs/ast@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/ast
+│  └─ licenseFile: node_modules/@webassemblyjs/ast/LICENSE
+├─ @webassemblyjs/floating-point-hex-parser@1.11.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Mauro Bringolf
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/floating-point-hex-parser
+│  └─ licenseFile: node_modules/@webassemblyjs/floating-point-hex-parser/LICENSE
+├─ @webassemblyjs/helper-api-error@1.11.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  └─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/helper-api-error
+├─ @webassemblyjs/helper-buffer@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/helper-buffer
+│  └─ licenseFile: node_modules/@webassemblyjs/helper-buffer/LICENSE
+├─ @webassemblyjs/helper-numbers@1.11.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  └─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/helper-numbers
+├─ @webassemblyjs/helper-wasm-bytecode@1.11.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  └─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/helper-wasm-bytecode
+├─ @webassemblyjs/helper-wasm-section@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/helper-wasm-section
+│  └─ licenseFile: node_modules/@webassemblyjs/helper-wasm-section/LICENSE
+├─ @webassemblyjs/ieee754@1.11.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  └─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/ieee754
+├─ @webassemblyjs/leb128@1.11.6
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/leb128
+│  └─ licenseFile: node_modules/@webassemblyjs/leb128/LICENSE.txt
+├─ @webassemblyjs/utf8@1.11.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  └─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/utf8
+├─ @webassemblyjs/wasm-edit@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/wasm-edit
+│  └─ licenseFile: node_modules/@webassemblyjs/wasm-edit/LICENSE
+├─ @webassemblyjs/wasm-gen@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/wasm-gen
+│  └─ licenseFile: node_modules/@webassemblyjs/wasm-gen/LICENSE
+├─ @webassemblyjs/wasm-opt@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/wasm-opt
+│  └─ licenseFile: node_modules/@webassemblyjs/wasm-opt/LICENSE
+├─ @webassemblyjs/wasm-parser@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/wasm-parser
+│  └─ licenseFile: node_modules/@webassemblyjs/wasm-parser/LICENSE
+├─ @webassemblyjs/wast-printer@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/webassemblyjs
+│  ├─ publisher: Sven Sauleau
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@webassemblyjs/wast-printer
+│  └─ licenseFile: node_modules/@webassemblyjs/wast-printer/LICENSE
+├─ @xtuc/ieee754@1.2.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/feross/ieee754
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: http://feross.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@xtuc/ieee754
+│  └─ licenseFile: node_modules/@xtuc/ieee754/LICENSE
+├─ @xtuc/long@4.2.2
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/dcodeIO/long.js
+│  ├─ publisher: Daniel Wirtz
+│  ├─ email: dcode@dcode.io
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/@xtuc/long
+│  └─ licenseFile: node_modules/@xtuc/long/LICENSE
+├─ abab@2.0.6
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/jsdom/abab
+│  ├─ publisher: Jeff Carpenter
+│  ├─ email: gcarpenterv@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/abab
+│  └─ licenseFile: node_modules/abab/LICENSE.md
+├─ accepts@1.3.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/accepts
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/accepts
+│  └─ licenseFile: node_modules/accepts/LICENSE
+├─ acorn-globals@6.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ForbesLindesay/acorn-globals
+│  ├─ publisher: ForbesLindesay
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/acorn-globals
+│  └─ licenseFile: node_modules/acorn-globals/LICENSE
+├─ acorn-import-attributes@1.9.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/xtuc/acorn-import-attributes
+│  ├─ publisher: Sven Sauleau
+│  ├─ email: sven@sauleau.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/acorn-import-attributes
+│  └─ licenseFile: node_modules/acorn-import-attributes/LICENSE
+├─ acorn-jsx@5.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn-jsx
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/acorn-jsx
+│  └─ licenseFile: node_modules/acorn-jsx/LICENSE
+├─ acorn-walk@7.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/acorn-walk
+│  └─ licenseFile: node_modules/acorn-walk/LICENSE
+├─ acorn@8.12.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/acornjs/acorn
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/acorn
+│  └─ licenseFile: node_modules/acorn/LICENSE
+├─ address@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/node-modules/address
+│  ├─ publisher: fengmk2
+│  ├─ email: fengmk2@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/address
+│  └─ licenseFile: node_modules/address/LICENSE.txt
+├─ adjust-sourcemap-loader@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bholloway/adjust-sourcemap-loader
+│  ├─ publisher: bholloway
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/adjust-sourcemap-loader
+│  └─ licenseFile: node_modules/adjust-sourcemap-loader/LICENSE
+├─ agent-base@6.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/node-agent-base
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/agent-base
+│  └─ licenseFile: node_modules/agent-base/README.md
+├─ ajv-keywords@3.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/ajv-keywords
+│  ├─ publisher: Evgeny Poberezkin
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ajv-keywords
+│  └─ licenseFile: node_modules/ajv-keywords/LICENSE
+├─ ajv@6.12.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ajv-validator/ajv
+│  ├─ publisher: Evgeny Poberezkin
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ajv
+│  └─ licenseFile: node_modules/ajv/LICENSE
+├─ ansi-escapes@4.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/ansi-escapes
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ansi-escapes
+│  └─ licenseFile: node_modules/ansi-escapes/license
+├─ ansi-html-community@0.0.8
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mahdyar/ansi-html-community
+│  ├─ publisher: mahdyar
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ansi-html-community
+│  └─ licenseFile: node_modules/ansi-html-community/LICENSE
+├─ ansi-html@0.0.9
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/Tjatse/ansi-html
+│  ├─ publisher: Tjatse
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ansi-html
+│  └─ licenseFile: node_modules/ansi-html/LICENSE
+├─ ansi-regex@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ansi-regex
+│  └─ licenseFile: node_modules/ansi-regex/license
+├─ ansi-styles@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/ansi-styles
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ansi-styles
+│  └─ licenseFile: node_modules/ansi-styles/license
+├─ any-promise@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevinbeaty/any-promise
+│  ├─ publisher: Kevin Beaty
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/any-promise
+│  └─ licenseFile: node_modules/any-promise/LICENSE
+├─ anymatch@3.1.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/micromatch/anymatch
+│  ├─ publisher: Elan Shanker
+│  ├─ url: https://github.com/es128
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/anymatch
+│  └─ licenseFile: node_modules/anymatch/LICENSE
+├─ arg@5.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vercel/arg
+│  ├─ publisher: Josh Junon
+│  ├─ email: junon@wavetilt.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/arg
+│  └─ licenseFile: node_modules/arg/LICENSE.md
+├─ argparse@1.0.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodeca/argparse
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/argparse
+│  └─ licenseFile: node_modules/argparse/LICENSE
+├─ aria-query@5.3.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/A11yance/aria-query
+│  ├─ publisher: Jesse Beach
+│  ├─ email: splendidnoise@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/aria-query
+│  └─ licenseFile: node_modules/aria-query/LICENSE
+├─ array-buffer-byte-length@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/array-buffer-byte-length
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array-buffer-byte-length
+│  └─ licenseFile: node_modules/array-buffer-byte-length/LICENSE
+├─ array-flatten@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/array-flatten
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array-flatten
+│  └─ licenseFile: node_modules/array-flatten/LICENSE
+├─ array-includes@3.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/array-includes
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array-includes
+│  └─ licenseFile: node_modules/array-includes/LICENSE
+├─ array-union@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/array-union
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array-union
+│  └─ licenseFile: node_modules/array-union/license
+├─ array.prototype.findlast@1.2.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Array.prototype.findLast
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array.prototype.findlast
+│  └─ licenseFile: node_modules/array.prototype.findlast/LICENSE
+├─ array.prototype.findlastindex@1.2.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Array.prototype.findLastIndex
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array.prototype.findlastindex
+│  └─ licenseFile: node_modules/array.prototype.findlastindex/LICENSE
+├─ array.prototype.flat@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Array.prototype.flat
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array.prototype.flat
+│  └─ licenseFile: node_modules/array.prototype.flat/LICENSE
+├─ array.prototype.flatmap@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Array.prototype.flatMap
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array.prototype.flatmap
+│  └─ licenseFile: node_modules/array.prototype.flatmap/LICENSE
+├─ array.prototype.reduce@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Array.prototype.reduce
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array.prototype.reduce
+│  └─ licenseFile: node_modules/array.prototype.reduce/LICENSE
+├─ array.prototype.toreversed@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Array.prototype.toReversed
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array.prototype.toreversed
+│  └─ licenseFile: node_modules/array.prototype.toreversed/LICENSE
+├─ array.prototype.tosorted@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Array.prototype.toSorted
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/array.prototype.tosorted
+│  └─ licenseFile: node_modules/array.prototype.tosorted/LICENSE
+├─ arraybuffer.prototype.slice@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/ArrayBuffer.prototype.slice
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/arraybuffer.prototype.slice
+│  └─ licenseFile: node_modules/arraybuffer.prototype.slice/LICENSE
+├─ asap@2.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kriskowal/asap
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/asap
+│  └─ licenseFile: node_modules/asap/LICENSE.md
+├─ ast-types-flow@0.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kyldvs/ast-types-flow
+│  ├─ publisher: kyldvs
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ast-types-flow
+│  └─ licenseFile: node_modules/ast-types-flow/LICENSE
+├─ async@3.2.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/caolan/async
+│  ├─ publisher: Caolan McMahon
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/async
+│  └─ licenseFile: node_modules/async/LICENSE
+├─ asynckit@0.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/alexindigo/asynckit
+│  ├─ publisher: Alex Indigo
+│  ├─ email: iam@alexindigo.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/asynckit
+│  └─ licenseFile: node_modules/asynckit/LICENSE
+├─ at-least-node@1.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/RyanZim/at-least-node
+│  ├─ publisher: Ryan Zimmerman
+│  ├─ email: opensrc@ryanzim.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/at-least-node
+│  └─ licenseFile: node_modules/at-least-node/LICENSE
+├─ autoprefixer@10.4.19
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/autoprefixer
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/autoprefixer
+│  └─ licenseFile: node_modules/autoprefixer/LICENSE
+├─ available-typed-arrays@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/available-typed-arrays
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/available-typed-arrays
+│  └─ licenseFile: node_modules/available-typed-arrays/LICENSE
+├─ axe-core@4.7.0
+│  ├─ licenses: MPL-2.0
+│  ├─ repository: https://github.com/dequelabs/axe-core
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/axe-core
+│  └─ licenseFile: node_modules/axe-core/LICENSE
+├─ axobject-query@3.2.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/A11yance/axobject-query
+│  ├─ publisher: Jesse Beach
+│  ├─ email: splendidnoise@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/axobject-query
+│  └─ licenseFile: node_modules/axobject-query/LICENSE
+├─ babel-jest@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-jest
+│  └─ licenseFile: node_modules/babel-jest/LICENSE
+├─ babel-loader@8.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-loader
+│  ├─ publisher: Luis Couto
+│  ├─ email: hello@luiscouto.pt
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-loader
+│  └─ licenseFile: node_modules/babel-loader/LICENSE
+├─ babel-plugin-istanbul@6.1.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/istanbuljs/babel-plugin-istanbul
+│  ├─ publisher: Thai Pangsakulyanont @dtinth
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-plugin-istanbul
+│  └─ licenseFile: node_modules/babel-plugin-istanbul/LICENSE
+├─ babel-plugin-jest-hoist@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-plugin-jest-hoist
+│  └─ licenseFile: node_modules/babel-plugin-jest-hoist/LICENSE
+├─ babel-plugin-macros@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kentcdodds/babel-plugin-macros
+│  ├─ publisher: Kent C. Dodds
+│  ├─ email: me@kentcdodds.com
+│  ├─ url: https://kentcdodds.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-plugin-macros
+│  └─ licenseFile: node_modules/babel-plugin-macros/LICENSE
+├─ babel-plugin-named-asset-import@0.3.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/create-react-app
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-plugin-named-asset-import
+│  └─ licenseFile: node_modules/babel-plugin-named-asset-import/LICENSE
+├─ babel-plugin-polyfill-corejs2@0.4.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-polyfills
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-plugin-polyfill-corejs2
+│  └─ licenseFile: node_modules/babel-plugin-polyfill-corejs2/LICENSE
+├─ babel-plugin-polyfill-corejs3@0.10.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-polyfills
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-plugin-polyfill-corejs3
+│  └─ licenseFile: node_modules/babel-plugin-polyfill-corejs3/LICENSE
+├─ babel-plugin-polyfill-regenerator@0.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/babel/babel-polyfills
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-plugin-polyfill-regenerator
+│  └─ licenseFile: node_modules/babel-plugin-polyfill-regenerator/LICENSE
+├─ babel-plugin-transform-react-remove-prop-types@0.4.24
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types
+│  ├─ publisher: Nikita Gusakov
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-plugin-transform-react-remove-prop-types
+│  └─ licenseFile: node_modules/babel-plugin-transform-react-remove-prop-types/LICENSE
+├─ babel-preset-current-node-syntax@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nicolo-ribaudo/babel-preset-current-node-syntax
+│  ├─ publisher: Nicolò Ribaudo
+│  ├─ url: https://github.com/nicolo-ribaudo
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-preset-current-node-syntax
+│  └─ licenseFile: node_modules/babel-preset-current-node-syntax/LICENSE
+├─ babel-preset-jest@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-preset-jest
+│  └─ licenseFile: node_modules/babel-preset-jest/LICENSE
+├─ babel-preset-react-app@10.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/create-react-app
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/babel-preset-react-app
+│  └─ licenseFile: node_modules/babel-preset-react-app/LICENSE
+├─ balanced-match@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/balanced-match
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/balanced-match
+│  └─ licenseFile: node_modules/balanced-match/LICENSE.md
+├─ batch@0.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/batch
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/batch
+│  └─ licenseFile: node_modules/batch/LICENSE
+├─ bfj@7.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: git+https://gitlab.com/philbooth/bfj
+│  ├─ publisher: Phil Booth
+│  ├─ url: https://gitlab.com/philbooth
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/bfj
+│  └─ licenseFile: node_modules/bfj/COPYING
+├─ big.js@5.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/MikeMcl/big.js
+│  ├─ publisher: Michael Mclaughlin
+│  ├─ email: M8ch88l@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/big.js
+│  └─ licenseFile: node_modules/big.js/LICENCE
+├─ binary-extensions@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/binary-extensions
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/binary-extensions
+│  └─ licenseFile: node_modules/binary-extensions/license
+├─ bluebird@3.7.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/petkaantonov/bluebird
+│  ├─ publisher: Petka Antonov
+│  ├─ email: petka_antonov@hotmail.com
+│  ├─ url: http://github.com/petkaantonov/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/bluebird
+│  └─ licenseFile: node_modules/bluebird/LICENSE
+├─ body-parser@1.20.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/body-parser
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/body-parser
+│  └─ licenseFile: node_modules/body-parser/LICENSE
+├─ bonjour-service@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/onlxltd/bonjour-service
+│  ├─ publisher: ON LX Lited
+│  ├─ email: team@onlx.ltd
+│  ├─ url: https://labs.onlx.ltd
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/bonjour-service
+│  └─ licenseFile: node_modules/bonjour-service/LICENSE
+├─ boolbase@1.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/fb55/boolbase
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/boolbase
+│  └─ licenseFile: node_modules/boolbase/README.md
+├─ brace-expansion@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/brace-expansion
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/brace-expansion
+│  └─ licenseFile: node_modules/brace-expansion/LICENSE
+├─ braces@3.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/braces
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/braces
+│  └─ licenseFile: node_modules/braces/LICENSE
+├─ browser-process-hrtime@1.0.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/kumavis/browser-process-hrtime
+│  ├─ publisher: kumavis
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/browser-process-hrtime
+│  └─ licenseFile: node_modules/browser-process-hrtime/LICENSE
+├─ browserslist@4.23.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserslist/browserslist
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/browserslist
+│  └─ licenseFile: node_modules/browserslist/LICENSE
+├─ bser@2.1.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/facebook/watchman
+│  ├─ publisher: Wez Furlong
+│  ├─ email: wez@fb.com
+│  ├─ url: http://wezfurlong.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/bser
+│  └─ licenseFile: node_modules/bser/README.md
+├─ buffer-from@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/LinusU/buffer-from
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/buffer-from
+│  └─ licenseFile: node_modules/buffer-from/LICENSE
+├─ builtin-modules@3.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/builtin-modules
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/builtin-modules
+│  └─ licenseFile: node_modules/builtin-modules/license
+├─ bytes@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/bytes.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ url: http://tjholowaychuk.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/bytes
+│  └─ licenseFile: node_modules/bytes/LICENSE
+├─ call-bind@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/call-bind
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/call-bind
+│  └─ licenseFile: node_modules/call-bind/LICENSE
+├─ callsites@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/callsites
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/callsites
+│  └─ licenseFile: node_modules/callsites/license
+├─ camel-case@4.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/change-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/camel-case
+│  └─ licenseFile: node_modules/camel-case/LICENSE
+├─ camelcase-css@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stevenvachon/camelcase-css
+│  ├─ publisher: Steven Vachon
+│  ├─ email: contact@svachon.com
+│  ├─ url: https://www.svachon.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/camelcase-css
+│  └─ licenseFile: node_modules/camelcase-css/license
+├─ camelcase@6.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/camelcase
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/camelcase
+│  └─ licenseFile: node_modules/camelcase/license
+├─ caniuse-api@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nyalab/caniuse-api
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/caniuse-api
+│  └─ licenseFile: node_modules/caniuse-api/LICENSE
+├─ caniuse-lite@1.0.30001636
+│  ├─ licenses: CC-BY-4.0
+│  ├─ repository: https://github.com/browserslist/caniuse-lite
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/caniuse-lite
+│  └─ licenseFile: node_modules/caniuse-lite/LICENSE
+├─ case-sensitive-paths-webpack-plugin@2.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Urthen/case-sensitive-paths-webpack-plugin
+│  ├─ publisher: Michael Pratt
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/case-sensitive-paths-webpack-plugin
+│  └─ licenseFile: node_modules/case-sensitive-paths-webpack-plugin/LICENSE
+├─ chalk@4.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/chalk
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/chalk
+│  └─ licenseFile: node_modules/chalk/license
+├─ char-regex@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Richienb/char-regex
+│  ├─ publisher: Richie Bendall
+│  ├─ email: richiebendall@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/char-regex
+│  └─ licenseFile: node_modules/char-regex/LICENSE
+├─ check-types@11.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: git+https://gitlab.com/philbooth/check-types.js
+│  ├─ publisher: Phil Booth
+│  ├─ email: pmbooth@gmail.com
+│  ├─ url: https://philbooth.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/check-types
+│  └─ licenseFile: node_modules/check-types/COPYING
+├─ chokidar@3.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/paulmillr/chokidar
+│  ├─ publisher: Paul Miller
+│  ├─ url: https://paulmillr.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/chokidar
+│  └─ licenseFile: node_modules/chokidar/LICENSE
+├─ chrome-trace-event@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/samccone/chrome-trace-event
+│  ├─ publisher: Trent Mick, Sam Saccone
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/chrome-trace-event
+│  └─ licenseFile: node_modules/chrome-trace-event/LICENSE.txt
+├─ ci-info@3.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/watson/ci-info
+│  ├─ publisher: Thomas Watson Steen
+│  ├─ email: w@tson.dk
+│  ├─ url: https://twitter.com/wa7son
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ci-info
+│  └─ licenseFile: node_modules/ci-info/LICENSE
+├─ cjs-module-lexer@1.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/cjs-module-lexer
+│  ├─ publisher: Guy Bedford
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cjs-module-lexer
+│  └─ licenseFile: node_modules/cjs-module-lexer/LICENSE
+├─ classnames@2.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/JedWatson/classnames
+│  ├─ publisher: Jed Watson
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/classnames
+│  └─ licenseFile: node_modules/classnames/LICENSE
+├─ clean-css@5.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/clean-css/clean-css
+│  ├─ publisher: Jakub Pawlowicz
+│  ├─ email: contact@jakubpawlowicz.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/clean-css
+│  └─ licenseFile: node_modules/clean-css/LICENSE
+├─ cliui@7.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/cliui
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cliui
+│  └─ licenseFile: node_modules/cliui/LICENSE.txt
+├─ co@4.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/co
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/co
+│  └─ licenseFile: node_modules/co/LICENSE
+├─ coa@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/veged/coa
+│  ├─ publisher: Sergey Berezhnoy
+│  ├─ email: veged@ya.ru
+│  ├─ url: http://github.com/veged
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/coa
+│  └─ licenseFile: node_modules/coa/LICENSE
+├─ collect-v8-coverage@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/SimenB/collect-v8-coverage
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/collect-v8-coverage
+│  └─ licenseFile: node_modules/collect-v8-coverage/LICENSE
+├─ color-convert@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Qix-/color-convert
+│  ├─ publisher: Heather Arthur
+│  ├─ email: fayearthur@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/color-convert
+│  └─ licenseFile: node_modules/color-convert/LICENSE
+├─ color-name@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/colorjs/color-name
+│  ├─ publisher: DY
+│  ├─ email: dfcreative@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/color-name
+│  └─ licenseFile: node_modules/color-name/LICENSE
+├─ colord@2.9.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/omgovich/colord
+│  ├─ publisher: Vlad Shilov
+│  ├─ email: omgovich@ya.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/colord
+│  └─ licenseFile: node_modules/colord/LICENSE.md
+├─ colorette@2.0.20
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jorgebucaran/colorette
+│  ├─ publisher: Jorge Bucaran
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/colorette
+│  └─ licenseFile: node_modules/colorette/LICENSE.md
+├─ combined-stream@1.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/felixge/node-combined-stream
+│  ├─ publisher: Felix Geisendörfer
+│  ├─ email: felix@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/combined-stream
+│  └─ licenseFile: node_modules/combined-stream/License
+├─ commander@2.20.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tj/commander.js
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/commander
+│  └─ licenseFile: node_modules/commander/LICENSE
+├─ common-tags@1.8.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zspecza/common-tags
+│  ├─ publisher: Declan de Wet
+│  ├─ email: declandewet@me.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/common-tags
+│  └─ licenseFile: node_modules/common-tags/license.md
+├─ commondir@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/node-commondir
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/commondir
+│  └─ licenseFile: node_modules/commondir/LICENSE
+├─ compressible@2.0.18
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/compressible
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/compressible
+│  └─ licenseFile: node_modules/compressible/LICENSE
+├─ compression@1.7.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/compression
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/compression
+│  └─ licenseFile: node_modules/compression/LICENSE
+├─ concat-map@0.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/node-concat-map
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/concat-map
+│  └─ licenseFile: node_modules/concat-map/LICENSE
+├─ concat-stream@1.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/maxogden/concat-stream
+│  ├─ publisher: Max Ogden
+│  ├─ email: max@maxogden.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/concat-stream
+│  └─ licenseFile: node_modules/concat-stream/LICENSE
+├─ confusing-browser-globals@1.0.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/create-react-app
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/confusing-browser-globals
+│  └─ licenseFile: node_modules/confusing-browser-globals/LICENSE
+├─ connect-history-api-fallback@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bripkens/connect-history-api-fallback
+│  ├─ publisher: Ben Ripkens
+│  ├─ email: bripkens@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/connect-history-api-fallback
+│  └─ licenseFile: node_modules/connect-history-api-fallback/LICENSE
+├─ content-disposition@0.5.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/content-disposition
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/content-disposition
+│  └─ licenseFile: node_modules/content-disposition/LICENSE
+├─ content-type@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/content-type
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/content-type
+│  └─ licenseFile: node_modules/content-type/LICENSE
+├─ convert-source-map@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thlorenz/convert-source-map
+│  ├─ publisher: Thorsten Lorenz
+│  ├─ email: thlorenz@gmx.de
+│  ├─ url: http://thlorenz.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/convert-source-map
+│  └─ licenseFile: node_modules/convert-source-map/LICENSE
+├─ cookie-signature@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/visionmedia/node-cookie-signature
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@learnboost.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cookie-signature
+│  └─ licenseFile: node_modules/cookie-signature/Readme.md
+├─ cookie@0.7.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/cookie
+│  ├─ publisher: Roman Shtylman
+│  ├─ email: shtylman@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cookie
+│  └─ licenseFile: node_modules/cookie/LICENSE
+├─ core-js-compat@3.37.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zloirock/core-js
+│  ├─ publisher: Denis Pushkarev
+│  ├─ email: zloirock@zloirock.ru
+│  ├─ url: http://zloirock.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/core-js-compat
+│  └─ licenseFile: node_modules/core-js-compat/LICENSE
+├─ core-js-pure@3.37.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zloirock/core-js
+│  ├─ publisher: Denis Pushkarev
+│  ├─ email: zloirock@zloirock.ru
+│  ├─ url: http://zloirock.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/core-js-pure
+│  └─ licenseFile: node_modules/core-js-pure/LICENSE
+├─ core-js@3.37.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zloirock/core-js
+│  ├─ publisher: Denis Pushkarev
+│  ├─ email: zloirock@zloirock.ru
+│  ├─ url: http://zloirock.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/core-js
+│  └─ licenseFile: node_modules/core-js/LICENSE
+├─ core-util-is@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/isaacs/core-util-is
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/core-util-is
+│  └─ licenseFile: node_modules/core-util-is/LICENSE
+├─ cosmiconfig@7.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/davidtheclark/cosmiconfig
+│  ├─ publisher: David Clark
+│  ├─ email: david.dave.clark@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cosmiconfig
+│  └─ licenseFile: node_modules/cosmiconfig/LICENSE
+├─ cross-fetch@3.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lquixada/cross-fetch
+│  ├─ publisher: Leonardo Quixada
+│  ├─ email: lquixada@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cross-fetch
+│  └─ licenseFile: node_modules/cross-fetch/LICENSE
+├─ cross-spawn@7.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/moxystudio/node-cross-spawn
+│  ├─ publisher: André Cruz
+│  ├─ email: andre@moxy.studio
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cross-spawn
+│  └─ licenseFile: node_modules/cross-spawn/LICENSE
+├─ crypto-random-string@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/crypto-random-string
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/crypto-random-string
+│  └─ licenseFile: node_modules/crypto-random-string/license
+├─ css-blank-pseudo@3.0.3
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-blank-pseudo
+│  └─ licenseFile: node_modules/css-blank-pseudo/LICENSE.md
+├─ css-declaration-sorter@6.4.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/Siilwyn/css-declaration-sorter
+│  ├─ publisher: Selwyn
+│  ├─ email: talk@selwyn.cc
+│  ├─ url: https://selwyn.cc/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-declaration-sorter
+│  └─ licenseFile: node_modules/css-declaration-sorter/license.md
+├─ css-has-pseudo@3.0.4
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-has-pseudo
+│  └─ licenseFile: node_modules/css-has-pseudo/LICENSE.md
+├─ css-loader@6.11.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/css-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-loader
+│  └─ licenseFile: node_modules/css-loader/LICENSE
+├─ css-minimizer-webpack-plugin@3.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/css-minimizer-webpack-plugin
+│  ├─ publisher: Loann Neveu
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-minimizer-webpack-plugin
+│  └─ licenseFile: node_modules/css-minimizer-webpack-plugin/LICENSE
+├─ css-prefers-color-scheme@6.0.3
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-prefers-color-scheme
+│  └─ licenseFile: node_modules/css-prefers-color-scheme/LICENSE.md
+├─ css-select-base-adapter@0.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nrkn/css-select-base-adapter
+│  ├─ publisher: Nik Coughlin
+│  ├─ email: nrkn.com@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-select-base-adapter
+│  └─ licenseFile: node_modules/css-select-base-adapter/LICENSE
+├─ css-select@4.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/css-select
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-select
+│  └─ licenseFile: node_modules/css-select/LICENSE
+├─ css-tree@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstree/csstree
+│  ├─ publisher: Roman Dvornov
+│  ├─ email: rdvornov@gmail.com
+│  ├─ url: https://github.com/lahmatiy
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-tree
+│  └─ licenseFile: node_modules/css-tree/LICENSE
+├─ css-what@6.1.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/css-what
+│  ├─ publisher: Felix Böhm
+│  ├─ email: me@feedic.com
+│  ├─ url: http://feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css-what
+│  └─ licenseFile: node_modules/css-what/LICENSE
+├─ css.escape@1.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/CSS.escape
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/css.escape
+│  └─ licenseFile: node_modules/css.escape/LICENSE-MIT.txt
+├─ cssdb@7.11.2
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/cssdb
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cssdb
+│  └─ licenseFile: node_modules/cssdb/LICENSE.md
+├─ cssesc@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/cssesc
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cssesc
+│  └─ licenseFile: node_modules/cssesc/LICENSE-MIT.txt
+├─ cssnano-preset-default@5.2.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cssnano-preset-default
+│  └─ licenseFile: node_modules/cssnano-preset-default/LICENSE-MIT
+├─ cssnano-utils@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cssnano-utils
+│  └─ licenseFile: node_modules/cssnano-utils/LICENSE
+├─ cssnano@5.1.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cssnano
+│  └─ licenseFile: node_modules/cssnano/LICENSE-MIT
+├─ csso@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/css/csso
+│  ├─ publisher: Sergey Kryzhanovsky
+│  ├─ email: skryzhanovsky@ya.ru
+│  ├─ url: https://github.com/afelix
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/csso
+│  └─ licenseFile: node_modules/csso/LICENSE
+├─ cssom@0.4.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/NV/CSSOM
+│  ├─ publisher: Nikita Vasilyev
+│  ├─ email: me@elv1s.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cssom
+│  └─ licenseFile: node_modules/cssom/LICENSE.txt
+├─ cssstyle@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/cssstyle
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/cssstyle
+│  └─ licenseFile: node_modules/cssstyle/LICENSE
+├─ csstype@3.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/frenic/csstype
+│  ├─ publisher: Fredrik Nicol
+│  ├─ email: fredrik.nicol@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/csstype
+│  └─ licenseFile: node_modules/csstype/LICENSE
+├─ damerau-levenshtein@1.0.8
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/tad-lispy/node-damerau-levenshtein
+│  ├─ publisher: The Spanish Inquisition
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/damerau-levenshtein
+│  └─ licenseFile: node_modules/damerau-levenshtein/LICENSE
+├─ data-urls@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/data-urls
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/data-urls
+│  └─ licenseFile: node_modules/data-urls/LICENSE.txt
+├─ data-view-buffer@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/data-view-buffer
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/data-view-buffer
+│  └─ licenseFile: node_modules/data-view-buffer/LICENSE
+├─ data-view-byte-length@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/data-view-byte-length
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/data-view-byte-length
+│  └─ licenseFile: node_modules/data-view-byte-length/LICENSE
+├─ data-view-byte-offset@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/data-view-byte-offset
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/data-view-byte-offset
+│  └─ licenseFile: node_modules/data-view-byte-offset/LICENSE
+├─ debug@4.3.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/debug-js/debug
+│  ├─ publisher: Josh Junon
+│  ├─ url: https://github.com/qix-
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/debug
+│  └─ licenseFile: node_modules/debug/LICENSE
+├─ decimal.js@10.4.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/MikeMcl/decimal.js
+│  ├─ publisher: Michael Mclaughlin
+│  ├─ email: M8ch88l@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/decimal.js
+│  └─ licenseFile: node_modules/decimal.js/LICENCE.md
+├─ dedent@0.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dmnd/dedent
+│  ├─ publisher: Desmond Brand
+│  ├─ email: dmnd@desmondbrand.com
+│  ├─ url: http://desmondbrand.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dedent
+│  └─ licenseFile: node_modules/dedent/LICENSE
+├─ deep-equal@2.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/node-deep-equal
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/deep-equal
+│  └─ licenseFile: node_modules/deep-equal/LICENSE
+├─ deep-is@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thlorenz/deep-is
+│  ├─ publisher: Thorsten Lorenz
+│  ├─ email: thlorenz@gmx.de
+│  ├─ url: http://thlorenz.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/deep-is
+│  └─ licenseFile: node_modules/deep-is/LICENSE
+├─ deepmerge@4.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TehShrike/deepmerge
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/deepmerge
+│  └─ licenseFile: node_modules/deepmerge/license.txt
+├─ default-gateway@6.0.3
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/silverwind/default-gateway
+│  ├─ publisher: silverwind
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/default-gateway
+│  └─ licenseFile: node_modules/default-gateway/LICENSE
+├─ define-data-property@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/define-data-property
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/define-data-property
+│  └─ licenseFile: node_modules/define-data-property/LICENSE
+├─ define-lazy-prop@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/define-lazy-prop
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/define-lazy-prop
+│  └─ licenseFile: node_modules/define-lazy-prop/license
+├─ define-properties@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/define-properties
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/define-properties
+│  └─ licenseFile: node_modules/define-properties/LICENSE
+├─ delayed-stream@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/felixge/node-delayed-stream
+│  ├─ publisher: Felix Geisendörfer
+│  ├─ email: felix@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/delayed-stream
+│  └─ licenseFile: node_modules/delayed-stream/License
+├─ depd@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dougwilson/nodejs-depd
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/depd
+│  └─ licenseFile: node_modules/depd/LICENSE
+├─ dequal@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/dequal
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dequal
+│  └─ licenseFile: node_modules/dequal/license
+├─ destroy@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stream-utils/destroy
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/destroy
+│  └─ licenseFile: node_modules/destroy/LICENSE
+├─ detect-newline@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/detect-newline
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/detect-newline
+│  └─ licenseFile: node_modules/detect-newline/license
+├─ detect-node@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/iliakan/detect-node
+│  ├─ publisher: Ilya Kantor
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/detect-node
+│  └─ licenseFile: node_modules/detect-node/LICENSE
+├─ detect-port-alt@1.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/node-modules/detect-port
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/detect-port-alt
+│  └─ licenseFile: node_modules/detect-port-alt/LICENSE
+├─ didyoumean@1.2.2
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/dcporter/didyoumean.js
+│  ├─ publisher: Dave Porter
+│  ├─ email: dcporter@gmail.com
+│  ├─ url: http://dcporter.net/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/didyoumean
+│  └─ licenseFile: node_modules/didyoumean/LICENSE
+├─ diff-sequences@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/diff-sequences
+│  └─ licenseFile: node_modules/diff-sequences/LICENSE
+├─ dir-glob@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevva/dir-glob
+│  ├─ publisher: Kevin Mårtensson
+│  ├─ email: kevinmartensson@gmail.com
+│  ├─ url: github.com/kevva
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dir-glob
+│  └─ licenseFile: node_modules/dir-glob/license
+├─ dlv@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/developit/dlv
+│  ├─ publisher: Jason Miller
+│  ├─ email: jason@developit.ca
+│  ├─ url: http://jasonformat.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dlv
+│  └─ licenseFile: node_modules/dlv/README.md
+├─ dns-packet@5.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/dns-packet
+│  ├─ publisher: Mathias Buus
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dns-packet
+│  └─ licenseFile: node_modules/dns-packet/LICENSE
+├─ doctrine@2.1.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/eslint/doctrine
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/doctrine
+│  └─ licenseFile: node_modules/doctrine/LICENSE
+├─ dom-accessibility-api@0.5.16
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eps1lon/dom-accessibility-api
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dom-accessibility-api
+│  └─ licenseFile: node_modules/dom-accessibility-api/LICENSE.md
+├─ dom-converter@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/AriaMinaei/dom-converter
+│  ├─ publisher: Aria Minaei
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dom-converter
+│  └─ licenseFile: node_modules/dom-converter/LICENSE
+├─ dom-serializer@1.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cheeriojs/dom-renderer
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dom-serializer
+│  └─ licenseFile: node_modules/dom-serializer/LICENSE
+├─ domelementtype@2.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/domelementtype
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/domelementtype
+│  └─ licenseFile: node_modules/domelementtype/LICENSE
+├─ domexception@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/domexception
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/domexception
+│  └─ licenseFile: node_modules/domexception/LICENSE.txt
+├─ domhandler@4.3.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/domhandler
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/domhandler
+│  └─ licenseFile: node_modules/domhandler/LICENSE
+├─ domutils@2.8.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/domutils
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/domutils
+│  └─ licenseFile: node_modules/domutils/LICENSE
+├─ dot-case@3.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/change-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dot-case
+│  └─ licenseFile: node_modules/dot-case/LICENSE
+├─ dotenv-expand@5.1.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ publisher: motdotla
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dotenv-expand
+│  └─ licenseFile: node_modules/dotenv-expand/LICENSE
+├─ dotenv@10.0.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/motdotla/dotenv
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/dotenv
+│  └─ licenseFile: node_modules/dotenv/LICENSE
+├─ duplexer@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/duplexer
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/duplexer
+│  └─ licenseFile: node_modules/duplexer/LICENCE
+├─ eastasianwidth@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/komagata/eastasianwidth
+│  ├─ publisher: Masaki Komagata
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eastasianwidth
+│  └─ licenseFile: node_modules/eastasianwidth/README.md
+├─ ee-first@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonathanong/ee-first
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ee-first
+│  └─ licenseFile: node_modules/ee-first/LICENSE
+├─ ejs@3.1.10
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mde/ejs
+│  ├─ publisher: Matthew Eernisse
+│  ├─ email: mde@fleegix.org
+│  ├─ url: http://fleegix.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ejs
+│  └─ licenseFile: node_modules/ejs/LICENSE
+├─ electron-to-chromium@1.4.805
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/kilian/electron-to-chromium
+│  ├─ publisher: Kilian Valkhof
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/electron-to-chromium
+│  └─ licenseFile: node_modules/electron-to-chromium/LICENSE
+├─ emittery@0.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/emittery
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/emittery
+│  └─ licenseFile: node_modules/emittery/license
+├─ emoji-regex@8.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/emoji-regex
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/emoji-regex
+│  └─ licenseFile: node_modules/emoji-regex/LICENSE-MIT.txt
+├─ emojis-list@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kikobeats/emojis-list
+│  ├─ publisher: Kiko Beats
+│  ├─ email: josefrancisco.verdu@gmail.com
+│  ├─ url: https://github.com/Kikobeats
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/emojis-list
+│  └─ licenseFile: node_modules/emojis-list/LICENSE.md
+├─ encodeurl@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/encodeurl
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/encodeurl
+│  └─ licenseFile: node_modules/encodeurl/LICENSE
+├─ enhanced-resolve@5.17.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/enhanced-resolve
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/enhanced-resolve
+│  └─ licenseFile: node_modules/enhanced-resolve/LICENSE
+├─ entities@2.2.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/entities
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/entities
+│  └─ licenseFile: node_modules/entities/LICENSE
+├─ error-ex@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/qix-/node-error-ex
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/error-ex
+│  └─ licenseFile: node_modules/error-ex/LICENSE
+├─ error-stack-parser@2.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stacktracejs/error-stack-parser
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/error-stack-parser
+│  └─ licenseFile: node_modules/error-stack-parser/LICENSE
+├─ es-abstract@1.23.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-abstract
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-abstract
+│  └─ licenseFile: node_modules/es-abstract/LICENSE
+├─ es-array-method-boxes-properly@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-array-method-boxes-properly
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-array-method-boxes-properly
+│  └─ licenseFile: node_modules/es-array-method-boxes-properly/LICENSE
+├─ es-define-property@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-define-property
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-define-property
+│  └─ licenseFile: node_modules/es-define-property/LICENSE
+├─ es-errors@1.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-errors
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-errors
+│  └─ licenseFile: node_modules/es-errors/LICENSE
+├─ es-get-iterator@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-get-iterator
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-get-iterator
+│  └─ licenseFile: node_modules/es-get-iterator/LICENSE
+├─ es-iterator-helpers@1.0.19
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/iterator-helpers
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-iterator-helpers
+│  └─ licenseFile: node_modules/es-iterator-helpers/LICENSE
+├─ es-module-lexer@1.5.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/guybedford/es-module-lexer
+│  ├─ publisher: Guy Bedford
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-module-lexer
+│  └─ licenseFile: node_modules/es-module-lexer/LICENSE
+├─ es-object-atoms@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-object-atoms
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-object-atoms
+│  └─ licenseFile: node_modules/es-object-atoms/LICENSE
+├─ es-set-tostringtag@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/es-set-tostringtag
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-set-tostringtag
+│  └─ licenseFile: node_modules/es-set-tostringtag/LICENSE
+├─ es-shim-unscopables@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-shim-unscopables
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-shim-unscopables
+│  └─ licenseFile: node_modules/es-shim-unscopables/LICENSE
+├─ es-to-primitive@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/es-to-primitive
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/es-to-primitive
+│  └─ licenseFile: node_modules/es-to-primitive/LICENSE
+├─ escalade@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/escalade
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/escalade
+│  └─ licenseFile: node_modules/escalade/license
+├─ escape-html@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/escape-html
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/escape-html
+│  └─ licenseFile: node_modules/escape-html/LICENSE
+├─ escape-string-regexp@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/escape-string-regexp
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/escape-string-regexp
+│  └─ licenseFile: node_modules/escape-string-regexp/license
+├─ escodegen@1.14.3
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/estools/escodegen
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/escodegen
+│  └─ licenseFile: node_modules/escodegen/LICENSE.BSD
+├─ eslint-config-react-app@7.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/create-react-app
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-config-react-app
+│  └─ licenseFile: node_modules/eslint-config-react-app/LICENSE
+├─ eslint-import-resolver-node@0.3.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/import-js/eslint-plugin-import
+│  ├─ publisher: Ben Mosher
+│  ├─ url: me@benmosher.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-import-resolver-node
+│  └─ licenseFile: node_modules/eslint-import-resolver-node/LICENSE
+├─ eslint-module-utils@2.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/import-js/eslint-plugin-import
+│  ├─ publisher: Ben Mosher
+│  ├─ email: me@benmosher.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-module-utils
+│  └─ licenseFile: node_modules/eslint-module-utils/LICENSE
+├─ eslint-plugin-flowtype@8.0.3
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/gajus/eslint-plugin-flowtype
+│  ├─ publisher: Gajus Kuizinas
+│  ├─ email: gajus@gajus.com
+│  ├─ url: http://gajus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-plugin-flowtype
+│  └─ licenseFile: node_modules/eslint-plugin-flowtype/LICENSE
+├─ eslint-plugin-import@2.29.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/import-js/eslint-plugin-import
+│  ├─ publisher: Ben Mosher
+│  ├─ email: me@benmosher.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-plugin-import
+│  └─ licenseFile: node_modules/eslint-plugin-import/LICENSE
+├─ eslint-plugin-jest@25.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jest-community/eslint-plugin-jest
+│  ├─ publisher: Jonathan Kim
+│  ├─ email: hello@jkimbo.com
+│  ├─ url: jkimbo.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-plugin-jest
+│  └─ licenseFile: node_modules/eslint-plugin-jest/LICENSE
+├─ eslint-plugin-jsx-a11y@6.8.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y
+│  ├─ publisher: Ethan Cohen
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-plugin-jsx-a11y
+│  └─ licenseFile: node_modules/eslint-plugin-jsx-a11y/LICENSE.md
+├─ eslint-plugin-react-hooks@4.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/react
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-plugin-react-hooks
+│  └─ licenseFile: node_modules/eslint-plugin-react-hooks/LICENSE
+├─ eslint-plugin-react@7.34.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsx-eslint/eslint-plugin-react
+│  ├─ publisher: Yannick Croissant
+│  ├─ email: yannick.croissant+npm@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-plugin-react
+│  └─ licenseFile: node_modules/eslint-plugin-react/LICENSE
+├─ eslint-plugin-testing-library@5.11.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/testing-library/eslint-plugin-testing-library
+│  ├─ publisher: Mario Beltrán Alarcón
+│  ├─ email: me@mario.dev
+│  ├─ url: https://mario.dev/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-plugin-testing-library
+│  └─ licenseFile: node_modules/eslint-plugin-testing-library/LICENSE
+├─ eslint-scope@5.1.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/eslint/eslint-scope
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-scope
+│  └─ licenseFile: node_modules/eslint-scope/LICENSE
+├─ eslint-visitor-keys@3.4.3
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/eslint/eslint-visitor-keys
+│  ├─ publisher: Toru Nagashima
+│  ├─ url: https://github.com/mysticatea
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-visitor-keys
+│  └─ licenseFile: node_modules/eslint-visitor-keys/LICENSE
+├─ eslint-webpack-plugin@3.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/eslint-webpack-plugin
+│  ├─ publisher: Ricardo Gobbo de Souza
+│  ├─ email: ricardogobbosouza@yahoo.com.br
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint-webpack-plugin
+│  └─ licenseFile: node_modules/eslint-webpack-plugin/LICENSE
+├─ eslint@8.57.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eslint/eslint
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ email: nicholas+npm@nczconsulting.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eslint
+│  └─ licenseFile: node_modules/eslint/LICENSE
+├─ espree@9.6.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/eslint/espree
+│  ├─ publisher: Nicholas C. Zakas
+│  ├─ email: nicholas+npm@nczconsulting.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/espree
+│  └─ licenseFile: node_modules/espree/LICENSE
+├─ esprima@4.0.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/jquery/esprima
+│  ├─ publisher: Ariya Hidayat
+│  ├─ email: ariya.hidayat@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/esprima
+│  └─ licenseFile: node_modules/esprima/LICENSE.BSD
+├─ esquery@1.5.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/estools/esquery
+│  ├─ publisher: Joel Feenstra
+│  ├─ email: jrfeenst+esquery@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/esquery
+│  └─ licenseFile: node_modules/esquery/license.txt
+├─ esrecurse@4.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/estools/esrecurse
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/esrecurse
+│  └─ licenseFile: node_modules/esrecurse/README.md
+├─ estraverse@5.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/estools/estraverse
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/estraverse
+│  └─ licenseFile: node_modules/estraverse/LICENSE.BSD
+├─ estree-walker@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Rich-Harris/estree-walker
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/estree-walker
+│  └─ licenseFile: node_modules/estree-walker/README.md
+├─ esutils@2.0.3
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/estools/esutils
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/esutils
+│  └─ licenseFile: node_modules/esutils/LICENSE.BSD
+├─ etag@1.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/etag
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/etag
+│  └─ licenseFile: node_modules/etag/LICENSE
+├─ eventemitter3@4.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/primus/eventemitter3
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/eventemitter3
+│  └─ licenseFile: node_modules/eventemitter3/LICENSE
+├─ events@3.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Gozala/events
+│  ├─ publisher: Irakli Gozalishvili
+│  ├─ email: rfobic@gmail.com
+│  ├─ url: http://jeditoolkit.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/events
+│  └─ licenseFile: node_modules/events/LICENSE
+├─ execa@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/execa
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/execa
+│  └─ licenseFile: node_modules/execa/license
+├─ exit@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cowboy/node-exit
+│  ├─ publisher: "Cowboy" Ben Alman
+│  ├─ url: http://benalman.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/exit
+│  └─ licenseFile: node_modules/exit/LICENSE-MIT
+├─ expect@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/expect
+│  └─ licenseFile: node_modules/expect/LICENSE
+├─ express@4.21.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/express
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/express
+│  └─ licenseFile: node_modules/express/LICENSE
+├─ fast-deep-equal@3.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/fast-deep-equal
+│  ├─ publisher: Evgeny Poberezkin
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fast-deep-equal
+│  └─ licenseFile: node_modules/fast-deep-equal/LICENSE
+├─ fast-glob@3.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mrmlnc/fast-glob
+│  ├─ publisher: Denis Malinochkin
+│  ├─ url: https://mrmlnc.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fast-glob
+│  └─ licenseFile: node_modules/fast-glob/LICENSE
+├─ fast-json-stable-stringify@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/fast-json-stable-stringify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fast-json-stable-stringify
+│  └─ licenseFile: node_modules/fast-json-stable-stringify/LICENSE
+├─ fast-levenshtein@2.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/hiddentao/fast-levenshtein
+│  ├─ publisher: Ramesh Nair
+│  ├─ email: ram@hiddentao.com
+│  ├─ url: http://www.hiddentao.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fast-levenshtein
+│  └─ licenseFile: node_modules/fast-levenshtein/LICENSE.md
+├─ fastq@1.17.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/mcollina/fastq
+│  ├─ publisher: Matteo Collina
+│  ├─ email: hello@matteocollina.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fastq
+│  └─ licenseFile: node_modules/fastq/LICENSE
+├─ faye-websocket@0.11.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/faye/faye-websocket-node
+│  ├─ publisher: James Coglan
+│  ├─ email: jcoglan@gmail.com
+│  ├─ url: http://jcoglan.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/faye-websocket
+│  └─ licenseFile: node_modules/faye-websocket/LICENSE.md
+├─ fb-watchman@2.0.2
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/facebook/watchman
+│  ├─ publisher: Wez Furlong
+│  ├─ email: wez@fb.com
+│  ├─ url: http://wezfurlong.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fb-watchman
+│  └─ licenseFile: node_modules/fb-watchman/README.md
+├─ file-entry-cache@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/royriojas/file-entry-cache
+│  ├─ publisher: Roy Riojas
+│  ├─ url: http://royriojas.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/file-entry-cache
+│  └─ licenseFile: node_modules/file-entry-cache/LICENSE
+├─ file-loader@6.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/file-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/file-loader
+│  └─ licenseFile: node_modules/file-loader/LICENSE
+├─ filelist@1.0.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/mde/filelist
+│  ├─ publisher: Matthew Eernisse
+│  ├─ email: mde@fleegix.org
+│  ├─ url: http://fleegix.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/filelist
+│  └─ licenseFile: node_modules/filelist/README.md
+├─ filesize@8.0.7
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/avoidwork/filesize.js
+│  ├─ publisher: Jason Mulligan
+│  ├─ email: jason.mulligan@avoidwork.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/filesize
+│  └─ licenseFile: node_modules/filesize/LICENSE
+├─ fill-range@7.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/fill-range
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fill-range
+│  └─ licenseFile: node_modules/fill-range/LICENSE
+├─ finalhandler@1.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/finalhandler
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/finalhandler
+│  └─ licenseFile: node_modules/finalhandler/LICENSE
+├─ find-cache-dir@3.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/avajs/find-cache-dir
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/find-cache-dir
+│  └─ licenseFile: node_modules/find-cache-dir/license
+├─ find-up@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/find-up
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/find-up
+│  └─ licenseFile: node_modules/find-up/license
+├─ flat-cache@3.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jaredwray/flat-cache
+│  ├─ publisher: Jared Wray
+│  ├─ url: https://jaredwray.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/flat-cache
+│  └─ licenseFile: node_modules/flat-cache/LICENSE
+├─ flatted@3.3.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/WebReflection/flatted
+│  ├─ publisher: Andrea Giammarchi
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/flatted
+│  └─ licenseFile: node_modules/flatted/LICENSE
+├─ follow-redirects@1.15.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/follow-redirects/follow-redirects
+│  ├─ publisher: Ruben Verborgh
+│  ├─ email: ruben@verborgh.org
+│  ├─ url: https://ruben.verborgh.org/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/follow-redirects
+│  └─ licenseFile: node_modules/follow-redirects/LICENSE
+├─ for-each@0.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/for-each
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/for-each
+│  └─ licenseFile: node_modules/for-each/LICENSE
+├─ foreground-child@3.2.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/tapjs/foreground-child
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/foreground-child
+│  └─ licenseFile: node_modules/foreground-child/LICENSE
+├─ fork-ts-checker-webpack-plugin@6.5.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TypeStrong/fork-ts-checker-webpack-plugin
+│  ├─ publisher: Piotr Oleś
+│  ├─ email: piotrek.oles@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fork-ts-checker-webpack-plugin
+│  └─ licenseFile: node_modules/fork-ts-checker-webpack-plugin/LICENSE
+├─ form-data@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/form-data/form-data
+│  ├─ publisher: Felix Geisendörfer
+│  ├─ email: felix@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/form-data
+│  └─ licenseFile: node_modules/form-data/License
+├─ forwarded@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/forwarded
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/forwarded
+│  └─ licenseFile: node_modules/forwarded/LICENSE
+├─ fraction.js@4.3.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rawify/Fraction.js
+│  ├─ publisher: Robert Eisele
+│  ├─ email: robert@raw.org
+│  ├─ url: https://raw.org/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fraction.js
+│  └─ licenseFile: node_modules/fraction.js/LICENSE
+├─ fresh@0.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/fresh
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ url: http://tjholowaychuk.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fresh
+│  └─ licenseFile: node_modules/fresh/LICENSE
+├─ fs-extra@9.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jprichardson/node-fs-extra
+│  ├─ publisher: JP Richardson
+│  ├─ email: jprichardson@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fs-extra
+│  └─ licenseFile: node_modules/fs-extra/LICENSE
+├─ fs-monkey@1.0.6
+│  ├─ licenses: Unlicense
+│  ├─ repository: https://github.com/streamich/fs-monkey
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fs-monkey
+│  └─ licenseFile: node_modules/fs-monkey/LICENSE
+├─ fs.realpath@1.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/fs.realpath
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fs.realpath
+│  └─ licenseFile: node_modules/fs.realpath/LICENSE
+├─ fsevents@2.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fsevents/fsevents
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/fsevents
+│  └─ licenseFile: node_modules/fsevents/LICENSE
+├─ function-bind@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Raynos/function-bind
+│  ├─ publisher: Raynos
+│  ├─ email: raynos2@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/function-bind
+│  └─ licenseFile: node_modules/function-bind/LICENSE
+├─ function.prototype.name@1.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Function.prototype.name
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/function.prototype.name
+│  └─ licenseFile: node_modules/function.prototype.name/LICENSE
+├─ functions-have-names@1.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/functions-have-names
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/functions-have-names
+│  └─ licenseFile: node_modules/functions-have-names/LICENSE
+├─ gensync@1.0.0-beta.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/loganfsmyth/gensync
+│  ├─ publisher: Logan Smyth
+│  ├─ email: loganfsmyth@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/gensync
+│  └─ licenseFile: node_modules/gensync/LICENSE
+├─ get-caller-file@2.0.5
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/stefanpenner/get-caller-file
+│  ├─ publisher: Stefan Penner
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/get-caller-file
+│  └─ licenseFile: node_modules/get-caller-file/LICENSE.md
+├─ get-intrinsic@1.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/get-intrinsic
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/get-intrinsic
+│  └─ licenseFile: node_modules/get-intrinsic/LICENSE
+├─ get-own-enumerable-property-symbols@3.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/mightyiam/get-own-enumerable-property-symbols
+│  ├─ publisher: Shahar Or
+│  ├─ email: mightyiampresence@gmail.com
+│  ├─ url: mightyiam
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/get-own-enumerable-property-symbols
+│  └─ licenseFile: node_modules/get-own-enumerable-property-symbols/LICENSE
+├─ get-package-type@0.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cfware/get-package-type
+│  ├─ publisher: Corey Farrell
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/get-package-type
+│  └─ licenseFile: node_modules/get-package-type/LICENSE
+├─ get-stream@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/get-stream
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/get-stream
+│  └─ licenseFile: node_modules/get-stream/license
+├─ get-symbol-description@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/get-symbol-description
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/get-symbol-description
+│  └─ licenseFile: node_modules/get-symbol-description/LICENSE
+├─ glob-parent@5.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/gulpjs/glob-parent
+│  ├─ publisher: Gulp Team
+│  ├─ email: team@gulpjs.com
+│  ├─ url: https://gulpjs.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/glob-parent
+│  └─ licenseFile: node_modules/glob-parent/LICENSE
+├─ glob-to-regexp@0.4.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fitzgen/glob-to-regexp
+│  ├─ publisher: Nick Fitzgerald
+│  ├─ email: fitzgen@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/glob-to-regexp
+│  └─ licenseFile: node_modules/glob-to-regexp/README.md
+├─ glob@7.2.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-glob
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/glob
+│  └─ licenseFile: node_modules/glob/LICENSE
+├─ global-modules@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/global-modules
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/global-modules
+│  └─ licenseFile: node_modules/global-modules/LICENSE
+├─ global-prefix@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/global-prefix
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/global-prefix
+│  └─ licenseFile: node_modules/global-prefix/LICENSE
+├─ globals@11.12.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/globals
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/globals
+│  └─ licenseFile: node_modules/globals/license
+├─ globalthis@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/System.global
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/globalthis
+│  └─ licenseFile: node_modules/globalthis/LICENSE
+├─ globby@11.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/globby
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/globby
+│  └─ licenseFile: node_modules/globby/license
+├─ gopd@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/gopd
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/gopd
+│  └─ licenseFile: node_modules/gopd/LICENSE
+├─ graceful-fs@4.2.11
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-graceful-fs
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/graceful-fs
+│  └─ licenseFile: node_modules/graceful-fs/LICENSE
+├─ graphemer@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/flmnt/graphemer
+│  ├─ publisher: Matt Davies
+│  ├─ email: matt@filament.so
+│  ├─ url: https://github.com/mattpauldavies
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/graphemer
+│  └─ licenseFile: node_modules/graphemer/LICENSE
+├─ gzip-size@6.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/gzip-size
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/gzip-size
+│  └─ licenseFile: node_modules/gzip-size/license
+├─ handle-thing@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/handle-thing
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/handle-thing
+│  └─ licenseFile: node_modules/handle-thing/README.md
+├─ harmony-reflect@1.6.2
+│  ├─ licenses: (Apache-2.0 OR MPL-1.1)
+│  ├─ repository: git+https://tvcutsem@github.com/tvcutsem/harmony-reflect
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/harmony-reflect
+│  └─ licenseFile: node_modules/harmony-reflect/README.md
+├─ has-bigints@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/has-bigints
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/has-bigints
+│  └─ licenseFile: node_modules/has-bigints/LICENSE
+├─ has-flag@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/has-flag
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/has-flag
+│  └─ licenseFile: node_modules/has-flag/license
+├─ has-property-descriptors@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/has-property-descriptors
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/has-property-descriptors
+│  └─ licenseFile: node_modules/has-property-descriptors/LICENSE
+├─ has-proto@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/has-proto
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/has-proto
+│  └─ licenseFile: node_modules/has-proto/LICENSE
+├─ has-symbols@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/has-symbols
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/has-symbols
+│  └─ licenseFile: node_modules/has-symbols/LICENSE
+├─ has-tostringtag@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/has-tostringtag
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/has-tostringtag
+│  └─ licenseFile: node_modules/has-tostringtag/LICENSE
+├─ hasown@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/hasOwn
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/hasown
+│  └─ licenseFile: node_modules/hasown/LICENSE
+├─ he@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/he
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/he
+│  └─ licenseFile: node_modules/he/LICENSE-MIT.txt
+├─ hoopy@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: git+https://gitlab.com/philbooth/hoopy
+│  ├─ publisher: Phil Booth
+│  ├─ email: pmbooth@gmail.com
+│  ├─ url: https://philbooth.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/hoopy
+│  └─ licenseFile: node_modules/hoopy/LICENSE
+├─ hpack.js@2.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/hpack.js
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/hpack.js
+│  └─ licenseFile: node_modules/hpack.js/README.md
+├─ html-encoding-sniffer@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/html-encoding-sniffer
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/html-encoding-sniffer
+│  └─ licenseFile: node_modules/html-encoding-sniffer/LICENSE.txt
+├─ html-entities@2.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mdevils/html-entities
+│  ├─ publisher: Marat Dulin
+│  ├─ email: mdevils@yandex.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/html-entities
+│  └─ licenseFile: node_modules/html-entities/LICENSE
+├─ html-escaper@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/WebReflection/html-escaper
+│  ├─ publisher: Andrea Giammarchi
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/html-escaper
+│  └─ licenseFile: node_modules/html-escaper/LICENSE.txt
+├─ html-minifier-terser@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/terser/html-minifier-terser
+│  ├─ publisher: Daniel Ruf
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/html-minifier-terser
+│  └─ licenseFile: node_modules/html-minifier-terser/LICENSE
+├─ html-parse-stringify@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/henrikjoreteg/html-parse-stringify
+│  ├─ publisher: Henrik Joreteg
+│  ├─ email: henrik@joreteg.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/html-parse-stringify
+│  └─ licenseFile: node_modules/html-parse-stringify/README.md
+├─ html-webpack-plugin@5.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jantimon/html-webpack-plugin
+│  ├─ publisher: Jan Nicklas
+│  ├─ email: j.nicklas@me.com
+│  ├─ url: https://github.com/jantimon
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/html-webpack-plugin
+│  └─ licenseFile: node_modules/html-webpack-plugin/LICENSE
+├─ htmlparser2@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fb55/htmlparser2
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/htmlparser2
+│  └─ licenseFile: node_modules/htmlparser2/LICENSE
+├─ http-deceiver@1.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/http-deceiver
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/http-deceiver
+│  └─ licenseFile: node_modules/http-deceiver/README.md
+├─ http-errors@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/http-errors
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/http-errors
+│  └─ licenseFile: node_modules/http-errors/LICENSE
+├─ http-parser-js@0.5.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/creationix/http-parser-js
+│  ├─ publisher: Tim Caswell
+│  ├─ url: https://github.com/creationix
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/http-parser-js
+│  └─ licenseFile: node_modules/http-parser-js/LICENSE.md
+├─ http-proxy-agent@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/node-http-proxy-agent
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/http-proxy-agent
+│  └─ licenseFile: node_modules/http-proxy-agent/README.md
+├─ http-proxy-middleware@2.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chimurai/http-proxy-middleware
+│  ├─ publisher: Steven Chim
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/http-proxy-middleware
+│  └─ licenseFile: node_modules/http-proxy-middleware/LICENSE
+├─ http-proxy@1.18.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/http-party/node-http-proxy
+│  ├─ publisher: Charlie Robbins
+│  ├─ email: charlie.robbins@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/http-proxy
+│  └─ licenseFile: node_modules/http-proxy/LICENSE
+├─ https-proxy-agent@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/node-https-proxy-agent
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/https-proxy-agent
+│  └─ licenseFile: node_modules/https-proxy-agent/README.md
+├─ human-signals@2.1.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/ehmicky/human-signals
+│  ├─ publisher: ehmicky
+│  ├─ email: ehmicky@gmail.com
+│  ├─ url: https://github.com/ehmicky
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/human-signals
+│  └─ licenseFile: node_modules/human-signals/LICENSE
+├─ i18n-js@3.9.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/fnando/i18n-js
+│  ├─ publisher: Nando Vieira
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/i18n-js
+│  └─ licenseFile: node_modules/i18n-js/README.md
+├─ i18next-browser-languagedetector@6.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/i18next/i18next-browser-languageDetector
+│  ├─ publisher: Jan Mühlemann
+│  ├─ email: jan.muehlemann@gmail.com
+│  ├─ url: https://github.com/jamuhl
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/i18next-browser-languagedetector
+│  └─ licenseFile: node_modules/i18next-browser-languagedetector/LICENSE
+├─ i18next-http-backend@1.4.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/i18next/i18next-http-backend
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/i18next-http-backend
+│  └─ licenseFile: node_modules/i18next-http-backend/licence
+├─ i18next@21.10.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/i18next/i18next
+│  ├─ publisher: Jan Mühlemann
+│  ├─ email: jan.muehlemann@gmail.com
+│  ├─ url: https://github.com/jamuhl
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/i18next
+│  └─ licenseFile: node_modules/i18next/LICENSE
+├─ iconv-lite@0.4.24
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ashtuchkin/iconv-lite
+│  ├─ publisher: Alexander Shtuchkin
+│  ├─ email: ashtuchkin@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/iconv-lite
+│  └─ licenseFile: node_modules/iconv-lite/LICENSE
+├─ icss-utils@5.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/css-modules/icss-utils
+│  ├─ publisher: Glen Maddern
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/icss-utils
+│  └─ licenseFile: node_modules/icss-utils/LICENSE.md
+├─ idb@7.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/jakearchibald/idb
+│  ├─ publisher: Jake Archibald
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/idb
+│  └─ licenseFile: node_modules/idb/LICENSE
+├─ identity-obj-proxy@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/keyanzhang/identity-obj-proxy
+│  ├─ publisher: Keyan Zhang
+│  ├─ email: root@keyanzhang.com
+│  ├─ url: http://keya.nz
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/identity-obj-proxy
+│  └─ licenseFile: node_modules/identity-obj-proxy/LICENSE
+├─ ignore@5.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kaelzhang/node-ignore
+│  ├─ publisher: kael
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ignore
+│  └─ licenseFile: node_modules/ignore/LICENSE-MIT
+├─ immer@9.0.21
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/immerjs/immer
+│  ├─ publisher: Michel Weststrate
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/immer
+│  └─ licenseFile: node_modules/immer/LICENSE
+├─ import-fresh@3.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/import-fresh
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/import-fresh
+│  └─ licenseFile: node_modules/import-fresh/license
+├─ import-local@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/import-local
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/import-local
+│  └─ licenseFile: node_modules/import-local/license
+├─ imurmurhash@0.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jensyt/imurmurhash-js
+│  ├─ publisher: Jens Taylor
+│  ├─ email: jensyt@gmail.com
+│  ├─ url: https://github.com/homebrewing
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/imurmurhash
+│  └─ licenseFile: node_modules/imurmurhash/README.md
+├─ indent-string@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/indent-string
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/indent-string
+│  └─ licenseFile: node_modules/indent-string/license
+├─ inflight@1.0.6
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/inflight
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/inflight
+│  └─ licenseFile: node_modules/inflight/LICENSE
+├─ inherits@2.0.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/inherits
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/inherits
+│  └─ licenseFile: node_modules/inherits/LICENSE
+├─ ini@1.3.8
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/ini
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ini
+│  └─ licenseFile: node_modules/ini/LICENSE
+├─ internal-slot@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/internal-slot
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/internal-slot
+│  └─ licenseFile: node_modules/internal-slot/LICENSE
+├─ ipaddr.js@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/whitequark/ipaddr.js
+│  ├─ publisher: whitequark
+│  ├─ email: whitequark@whitequark.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ipaddr.js
+│  └─ licenseFile: node_modules/ipaddr.js/LICENSE
+├─ is-arguments@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-arguments
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-arguments
+│  └─ licenseFile: node_modules/is-arguments/LICENSE
+├─ is-array-buffer@3.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-array-buffer
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-array-buffer
+│  └─ licenseFile: node_modules/is-array-buffer/LICENSE
+├─ is-arrayish@0.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/qix-/node-is-arrayish
+│  ├─ publisher: Qix
+│  ├─ url: http://github.com/qix-
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-arrayish
+│  └─ licenseFile: node_modules/is-arrayish/LICENSE
+├─ is-async-function@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-async-function
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-async-function
+│  └─ licenseFile: node_modules/is-async-function/LICENSE
+├─ is-bigint@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-bigint
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-bigint
+│  └─ licenseFile: node_modules/is-bigint/LICENSE
+├─ is-binary-path@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-binary-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-binary-path
+│  └─ licenseFile: node_modules/is-binary-path/license
+├─ is-boolean-object@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-boolean-object
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-boolean-object
+│  └─ licenseFile: node_modules/is-boolean-object/LICENSE
+├─ is-callable@1.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-callable
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-callable
+│  └─ licenseFile: node_modules/is-callable/LICENSE
+├─ is-core-module@2.13.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-core-module
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-core-module
+│  └─ licenseFile: node_modules/is-core-module/LICENSE
+├─ is-data-view@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-data-view
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-data-view
+│  └─ licenseFile: node_modules/is-data-view/LICENSE
+├─ is-date-object@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-date-object
+│  ├─ publisher: Jordan Harband
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-date-object
+│  └─ licenseFile: node_modules/is-date-object/LICENSE
+├─ is-docker@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-docker
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-docker
+│  └─ licenseFile: node_modules/is-docker/license
+├─ is-extglob@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-extglob
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-extglob
+│  └─ licenseFile: node_modules/is-extglob/LICENSE
+├─ is-finalizationregistry@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-finalizationregistry
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-finalizationregistry
+│  └─ licenseFile: node_modules/is-finalizationregistry/LICENSE
+├─ is-fullwidth-code-point@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-fullwidth-code-point
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-fullwidth-code-point
+│  └─ licenseFile: node_modules/is-fullwidth-code-point/license
+├─ is-generator-fn@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-generator-fn
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-generator-fn
+│  └─ licenseFile: node_modules/is-generator-fn/license
+├─ is-generator-function@1.0.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-generator-function
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-generator-function
+│  └─ licenseFile: node_modules/is-generator-function/LICENSE
+├─ is-glob@4.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/is-glob
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-glob
+│  └─ licenseFile: node_modules/is-glob/LICENSE
+├─ is-map@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-map
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-map
+│  └─ licenseFile: node_modules/is-map/LICENSE
+├─ is-module@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/is-module
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-module
+│  └─ licenseFile: node_modules/is-module/README.md
+├─ is-negative-zero@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-negative-zero
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-negative-zero
+│  └─ licenseFile: node_modules/is-negative-zero/LICENSE
+├─ is-number-object@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-number-object
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-number-object
+│  └─ licenseFile: node_modules/is-number-object/LICENSE
+├─ is-number@7.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/is-number
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-number
+│  └─ licenseFile: node_modules/is-number/LICENSE
+├─ is-obj@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-obj
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-obj
+│  └─ licenseFile: node_modules/is-obj/license
+├─ is-path-inside@3.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-path-inside
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-path-inside
+│  └─ licenseFile: node_modules/is-path-inside/license
+├─ is-plain-obj@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-plain-obj
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-plain-obj
+│  └─ licenseFile: node_modules/is-plain-obj/license
+├─ is-potential-custom-element-name@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/is-potential-custom-element-name
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-potential-custom-element-name
+│  └─ licenseFile: node_modules/is-potential-custom-element-name/LICENSE-MIT.txt
+├─ is-regex@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-regex
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-regex
+│  └─ licenseFile: node_modules/is-regex/LICENSE
+├─ is-regexp@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-regexp
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: http://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-regexp
+│  └─ licenseFile: node_modules/is-regexp/readme.md
+├─ is-root@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-root
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-root
+│  └─ licenseFile: node_modules/is-root/license
+├─ is-set@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-set
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-set
+│  └─ licenseFile: node_modules/is-set/LICENSE
+├─ is-shared-array-buffer@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-shared-array-buffer
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-shared-array-buffer
+│  └─ licenseFile: node_modules/is-shared-array-buffer/LICENSE
+├─ is-stream@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-stream
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-stream
+│  └─ licenseFile: node_modules/is-stream/license
+├─ is-string@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/is-string
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-string
+│  └─ licenseFile: node_modules/is-string/LICENSE
+├─ is-symbol@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-symbol
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-symbol
+│  └─ licenseFile: node_modules/is-symbol/LICENSE
+├─ is-typed-array@1.1.13
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-typed-array
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-typed-array
+│  └─ licenseFile: node_modules/is-typed-array/LICENSE
+├─ is-typedarray@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/hughsk/is-typedarray
+│  ├─ publisher: Hugh Kennedy
+│  ├─ email: hughskennedy@gmail.com
+│  ├─ url: http://hughsk.io/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-typedarray
+│  └─ licenseFile: node_modules/is-typedarray/LICENSE.md
+├─ is-weakmap@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-weakmap
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-weakmap
+│  └─ licenseFile: node_modules/is-weakmap/LICENSE
+├─ is-weakref@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-weakref
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-weakref
+│  └─ licenseFile: node_modules/is-weakref/LICENSE
+├─ is-weakset@2.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/is-weakset
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-weakset
+│  └─ licenseFile: node_modules/is-weakset/LICENSE
+├─ is-wsl@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/is-wsl
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/is-wsl
+│  └─ licenseFile: node_modules/is-wsl/license
+├─ isarray@2.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/juliangruber/isarray
+│  ├─ publisher: Julian Gruber
+│  ├─ email: mail@juliangruber.com
+│  ├─ url: http://juliangruber.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/isarray
+│  └─ licenseFile: node_modules/isarray/LICENSE
+├─ isexe@2.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/isexe
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/isexe
+│  └─ licenseFile: node_modules/isexe/LICENSE
+├─ istanbul-lib-coverage@3.2.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/istanbuljs/istanbuljs
+│  ├─ publisher: Krishnan Anantheswaran
+│  ├─ email: kananthmail-github@yahoo.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/istanbul-lib-coverage
+│  └─ licenseFile: node_modules/istanbul-lib-coverage/LICENSE
+├─ istanbul-lib-instrument@5.2.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/istanbuljs/istanbuljs
+│  ├─ publisher: Krishnan Anantheswaran
+│  ├─ email: kananthmail-github@yahoo.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/istanbul-lib-instrument
+│  └─ licenseFile: node_modules/istanbul-lib-instrument/LICENSE
+├─ istanbul-lib-report@3.0.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/istanbuljs/istanbuljs
+│  ├─ publisher: Krishnan Anantheswaran
+│  ├─ email: kananthmail-github@yahoo.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/istanbul-lib-report
+│  └─ licenseFile: node_modules/istanbul-lib-report/LICENSE
+├─ istanbul-lib-source-maps@4.0.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/istanbuljs/istanbuljs
+│  ├─ publisher: Krishnan Anantheswaran
+│  ├─ email: kananthmail-github@yahoo.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/istanbul-lib-source-maps
+│  └─ licenseFile: node_modules/istanbul-lib-source-maps/LICENSE
+├─ istanbul-reports@3.1.7
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/istanbuljs/istanbuljs
+│  ├─ publisher: Krishnan Anantheswaran
+│  ├─ email: kananthmail-github@yahoo.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/istanbul-reports
+│  └─ licenseFile: node_modules/istanbul-reports/LICENSE
+├─ iterator.prototype@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/Iterator.prototype
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/iterator.prototype
+│  └─ licenseFile: node_modules/iterator.prototype/LICENSE
+├─ jackspeak@3.4.0
+│  ├─ licenses: BlueOak-1.0.0
+│  ├─ repository: https://github.com/isaacs/jackspeak
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jackspeak
+│  └─ licenseFile: node_modules/jackspeak/LICENSE.md
+├─ jake@10.9.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/jakejs/jake
+│  ├─ publisher: Matthew Eernisse
+│  ├─ email: mde@fleegix.org
+│  ├─ url: http://fleegix.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jake
+│  └─ licenseFile: node_modules/jake/README.md
+├─ jest-changed-files@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-changed-files
+│  └─ licenseFile: node_modules/jest-changed-files/LICENSE
+├─ jest-circus@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-circus
+│  └─ licenseFile: node_modules/jest-circus/LICENSE
+├─ jest-cli@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-cli
+│  └─ licenseFile: node_modules/jest-cli/LICENSE
+├─ jest-config@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-config
+│  └─ licenseFile: node_modules/jest-config/LICENSE
+├─ jest-diff@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-diff
+│  └─ licenseFile: node_modules/jest-diff/LICENSE
+├─ jest-docblock@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-docblock
+│  └─ licenseFile: node_modules/jest-docblock/LICENSE
+├─ jest-each@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ publisher: Matt Phillips
+│  ├─ url: mattphillips
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-each
+│  └─ licenseFile: node_modules/jest-each/LICENSE
+├─ jest-environment-jsdom@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-environment-jsdom
+│  └─ licenseFile: node_modules/jest-environment-jsdom/LICENSE
+├─ jest-environment-node@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-environment-node
+│  └─ licenseFile: node_modules/jest-environment-node/LICENSE
+├─ jest-get-type@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-get-type
+│  └─ licenseFile: node_modules/jest-get-type/LICENSE
+├─ jest-haste-map@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-haste-map
+│  └─ licenseFile: node_modules/jest-haste-map/LICENSE
+├─ jest-jasmine2@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-jasmine2
+│  └─ licenseFile: node_modules/jest-jasmine2/LICENSE
+├─ jest-leak-detector@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-leak-detector
+│  └─ licenseFile: node_modules/jest-leak-detector/LICENSE
+├─ jest-matcher-utils@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-matcher-utils
+│  └─ licenseFile: node_modules/jest-matcher-utils/LICENSE
+├─ jest-message-util@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-message-util
+│  └─ licenseFile: node_modules/jest-message-util/LICENSE
+├─ jest-mock@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-mock
+│  └─ licenseFile: node_modules/jest-mock/LICENSE
+├─ jest-pnp-resolver@1.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/arcanis/jest-pnp-resolver
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-pnp-resolver
+│  └─ licenseFile: node_modules/jest-pnp-resolver/README.md
+├─ jest-regex-util@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-regex-util
+│  └─ licenseFile: node_modules/jest-regex-util/LICENSE
+├─ jest-resolve-dependencies@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-resolve-dependencies
+│  └─ licenseFile: node_modules/jest-resolve-dependencies/LICENSE
+├─ jest-resolve@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-resolve
+│  └─ licenseFile: node_modules/jest-resolve/LICENSE
+├─ jest-runner@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-runner
+│  └─ licenseFile: node_modules/jest-runner/LICENSE
+├─ jest-runtime@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-runtime
+│  └─ licenseFile: node_modules/jest-runtime/LICENSE
+├─ jest-serializer@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-serializer
+│  └─ licenseFile: node_modules/jest-serializer/LICENSE
+├─ jest-snapshot@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-snapshot
+│  └─ licenseFile: node_modules/jest-snapshot/LICENSE
+├─ jest-util@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-util
+│  └─ licenseFile: node_modules/jest-util/LICENSE
+├─ jest-validate@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-validate
+│  └─ licenseFile: node_modules/jest-validate/LICENSE
+├─ jest-watch-typeahead@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jest-community/jest-watch-typeahead
+│  ├─ publisher: Rogelio Guzman
+│  ├─ email: rogelioguzmanh@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-watch-typeahead
+│  └─ licenseFile: node_modules/jest-watch-typeahead/LICENSE
+├─ jest-watcher@28.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-watcher
+│  └─ licenseFile: node_modules/jest-watcher/LICENSE
+├─ jest-worker@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest-worker
+│  └─ licenseFile: node_modules/jest-worker/LICENSE
+├─ jest@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jest
+│  └─ licenseFile: node_modules/jest/LICENSE
+├─ jiti@1.21.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/unjs/jiti
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jiti
+│  └─ licenseFile: node_modules/jiti/LICENSE
+├─ js-tokens@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lydell/js-tokens
+│  ├─ publisher: Simon Lydell
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/js-tokens
+│  └─ licenseFile: node_modules/js-tokens/LICENSE
+├─ js-yaml@3.14.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodeca/js-yaml
+│  ├─ publisher: Vladimir Zapparov
+│  ├─ email: dervus.grim@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/js-yaml
+│  └─ licenseFile: node_modules/js-yaml/LICENSE
+├─ jsdom@16.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/jsdom
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jsdom
+│  └─ licenseFile: node_modules/jsdom/LICENSE.txt
+├─ jsesc@2.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/jsesc
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jsesc
+│  └─ licenseFile: node_modules/jsesc/LICENSE-MIT.txt
+├─ json-buffer@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dominictarr/json-buffer
+│  ├─ publisher: Dominic Tarr
+│  ├─ email: dominic.tarr@gmail.com
+│  ├─ url: http://dominictarr.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/json-buffer
+│  └─ licenseFile: node_modules/json-buffer/LICENSE
+├─ json-parse-even-better-errors@2.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/npm/json-parse-even-better-errors
+│  ├─ publisher: Kat Marchán
+│  ├─ email: kzm@zkat.tech
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/json-parse-even-better-errors
+│  └─ licenseFile: node_modules/json-parse-even-better-errors/LICENSE.md
+├─ json-schema-traverse@0.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/epoberezkin/json-schema-traverse
+│  ├─ publisher: Evgeny Poberezkin
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/json-schema-traverse
+│  └─ licenseFile: node_modules/json-schema-traverse/LICENSE
+├─ json-schema@0.4.0
+│  ├─ licenses: (AFL-2.1 OR BSD-3-Clause)
+│  ├─ repository: https://github.com/kriszyp/json-schema
+│  ├─ publisher: Kris Zyp
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/json-schema
+│  └─ licenseFile: node_modules/json-schema/LICENSE
+├─ json-stable-stringify-without-jsonify@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/samn/json-stable-stringify
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/json-stable-stringify-without-jsonify
+│  └─ licenseFile: node_modules/json-stable-stringify-without-jsonify/LICENSE
+├─ json5@2.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/json5/json5
+│  ├─ publisher: Aseem Kishore
+│  ├─ email: aseem.kishore@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/json5
+│  └─ licenseFile: node_modules/json5/LICENSE.md
+├─ jsonfile@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jprichardson/node-jsonfile
+│  ├─ publisher: JP Richardson
+│  ├─ email: jprichardson@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jsonfile
+│  └─ licenseFile: node_modules/jsonfile/LICENSE
+├─ jsonpath@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dchester/jsonpath
+│  ├─ publisher: david@fmail.co.uk
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jsonpath
+│  └─ licenseFile: node_modules/jsonpath/LICENSE
+├─ jsonpointer@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/janl/node-jsonpointer
+│  ├─ publisher: Jan Lehnardt
+│  ├─ email: jan@apache.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jsonpointer
+│  └─ licenseFile: node_modules/jsonpointer/LICENSE.md
+├─ jsx-ast-utils@3.3.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsx-eslint/jsx-ast-utils
+│  ├─ publisher: Ethan Cohen
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jsx-ast-utils
+│  └─ licenseFile: node_modules/jsx-ast-utils/LICENSE.md
+├─ jwt-decode@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/auth0/jwt-decode
+│  ├─ publisher: Jose F. Romaniello
+│  ├─ email: jfromaniello@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/jwt-decode
+│  └─ licenseFile: node_modules/jwt-decode/LICENSE
+├─ keyv@4.5.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jaredwray/keyv
+│  ├─ publisher: Jared Wray
+│  ├─ email: me@jaredwray.com
+│  ├─ url: http://jaredwray.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/keyv
+│  └─ licenseFile: node_modules/keyv/README.md
+├─ kind-of@6.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/kind-of
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/kind-of
+│  └─ licenseFile: node_modules/kind-of/LICENSE
+├─ kleur@3.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/kleur
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: lukeed.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/kleur
+│  └─ licenseFile: node_modules/kleur/license
+├─ klona@2.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/klona
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/klona
+│  └─ licenseFile: node_modules/klona/license
+├─ language-subtag-registry@0.3.23
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/mattcg/language-subtag-registry
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/language-subtag-registry
+│  └─ licenseFile: node_modules/language-subtag-registry/README.md
+├─ language-tags@1.0.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mattcg/language-tags
+│  ├─ publisher: Matthew Caruana Galizia
+│  ├─ email: mattcg@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/language-tags
+│  └─ licenseFile: node_modules/language-tags/README.md
+├─ launch-editor@2.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yyx990803/launch-editor
+│  ├─ publisher: Evan You
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/launch-editor
+│  └─ licenseFile: node_modules/launch-editor/LICENSE
+├─ legalagedemo@2.0.2
+│  ├─ licenses: UNLICENSED
+│  ├─ private: true
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo
+│  └─ licenseFile: README.md
+├─ leven@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/leven
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/leven
+│  └─ licenseFile: node_modules/leven/license
+├─ levn@0.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gkz/levn
+│  ├─ publisher: George Zahariev
+│  ├─ email: z@georgezahariev.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/levn
+│  └─ licenseFile: node_modules/levn/LICENSE
+├─ lilconfig@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/antonk52/lilconfig
+│  ├─ publisher: antonk52
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lilconfig
+│  └─ licenseFile: node_modules/lilconfig/LICENSE
+├─ lines-and-columns@1.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/eventualbuddha/lines-and-columns
+│  ├─ publisher: Brian Donovan
+│  ├─ email: brian@donovans.cc
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lines-and-columns
+│  └─ licenseFile: node_modules/lines-and-columns/LICENSE
+├─ loader-runner@4.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/loader-runner
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/loader-runner
+│  └─ licenseFile: node_modules/loader-runner/LICENSE
+├─ loader-utils@2.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/loader-utils
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/loader-utils
+│  └─ licenseFile: node_modules/loader-utils/LICENSE
+├─ locate-path@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/locate-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/locate-path
+│  └─ licenseFile: node_modules/locate-path/license
+├─ lodash.debounce@4.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lodash.debounce
+│  └─ licenseFile: node_modules/lodash.debounce/LICENSE
+├─ lodash.memoize@4.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lodash.memoize
+│  └─ licenseFile: node_modules/lodash.memoize/LICENSE
+├─ lodash.merge@4.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lodash.merge
+│  └─ licenseFile: node_modules/lodash.merge/LICENSE
+├─ lodash.sortby@4.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lodash.sortby
+│  └─ licenseFile: node_modules/lodash.sortby/LICENSE
+├─ lodash.uniq@4.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ url: http://allyoucanleet.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lodash.uniq
+│  └─ licenseFile: node_modules/lodash.uniq/LICENSE
+├─ lodash@4.17.21
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lodash/lodash
+│  ├─ publisher: John-David Dalton
+│  ├─ email: john.david.dalton@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lodash
+│  └─ licenseFile: node_modules/lodash/LICENSE
+├─ loose-envify@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/zertosh/loose-envify
+│  ├─ publisher: Andres Suarez
+│  ├─ email: zertosh@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/loose-envify
+│  └─ licenseFile: node_modules/loose-envify/LICENSE
+├─ lower-case@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/change-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lower-case
+│  └─ licenseFile: node_modules/lower-case/LICENSE
+├─ lru-cache@5.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-lru-cache
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lru-cache
+│  └─ licenseFile: node_modules/lru-cache/LICENSE
+├─ lz-string@1.5.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pieroxy/lz-string
+│  ├─ publisher: pieroxy
+│  ├─ email: pieroxy@pieroxy.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/lz-string
+│  └─ licenseFile: node_modules/lz-string/LICENSE
+├─ magic-string@0.25.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rich-harris/magic-string
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/magic-string
+│  └─ licenseFile: node_modules/magic-string/LICENSE
+├─ make-dir@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/make-dir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/make-dir
+│  └─ licenseFile: node_modules/make-dir/license
+├─ makeerror@1.0.12
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/daaku/nodejs-makeerror
+│  ├─ publisher: Naitik Shah
+│  ├─ email: n@daaku.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/makeerror
+│  └─ licenseFile: node_modules/makeerror/license
+├─ mdn-data@2.0.14
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/mdn/data
+│  ├─ publisher: Mozilla Developer Network
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/mdn-data
+│  └─ licenseFile: node_modules/mdn-data/LICENSE
+├─ media-typer@0.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/media-typer
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/media-typer
+│  └─ licenseFile: node_modules/media-typer/LICENSE
+├─ memfs@3.6.0
+│  ├─ licenses: Unlicense
+│  ├─ repository: https://github.com/streamich/memfs
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/memfs
+│  └─ licenseFile: node_modules/memfs/LICENSE
+├─ merge-descriptors@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/merge-descriptors
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/merge-descriptors
+│  └─ licenseFile: node_modules/merge-descriptors/LICENSE
+├─ merge-stream@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/grncdr/merge-stream
+│  ├─ publisher: Stephen Sugden
+│  ├─ email: me@stephensugden.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/merge-stream
+│  └─ licenseFile: node_modules/merge-stream/LICENSE
+├─ merge2@1.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/teambition/merge2
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/merge2
+│  └─ licenseFile: node_modules/merge2/LICENSE
+├─ methods@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/methods
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/methods
+│  └─ licenseFile: node_modules/methods/LICENSE
+├─ micromatch@4.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/micromatch
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/micromatch
+│  └─ licenseFile: node_modules/micromatch/LICENSE
+├─ mime-db@1.52.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/mime-db
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/mime-db
+│  └─ licenseFile: node_modules/mime-db/LICENSE
+├─ mime-types@2.1.35
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/mime-types
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/mime-types
+│  └─ licenseFile: node_modules/mime-types/LICENSE
+├─ mime@1.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/broofa/node-mime
+│  ├─ publisher: Robert Kieffer
+│  ├─ email: robert@broofa.com
+│  ├─ url: http://github.com/broofa
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/mime
+│  └─ licenseFile: node_modules/mime/LICENSE
+├─ mimic-fn@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/mimic-fn
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/mimic-fn
+│  └─ licenseFile: node_modules/mimic-fn/license
+├─ min-indent@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thejameskyle/min-indent
+│  ├─ publisher: James Kyle
+│  ├─ email: me@thejameskyle.com
+│  ├─ url: thejameskyle.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/min-indent
+│  └─ licenseFile: node_modules/min-indent/license
+├─ mini-css-extract-plugin@2.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/mini-css-extract-plugin
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/mini-css-extract-plugin
+│  └─ licenseFile: node_modules/mini-css-extract-plugin/LICENSE
+├─ minimalistic-assert@1.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/calvinmetcalf/minimalistic-assert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/minimalistic-assert
+│  └─ licenseFile: node_modules/minimalistic-assert/LICENSE
+├─ minimatch@3.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minimatch
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/minimatch
+│  └─ licenseFile: node_modules/minimatch/LICENSE
+├─ minimist@1.2.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/minimistjs/minimist
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/minimist
+│  └─ licenseFile: node_modules/minimist/LICENSE
+├─ minipass@7.1.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/minipass
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/minipass
+│  └─ licenseFile: node_modules/minipass/LICENSE
+├─ mkdirp@0.5.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/node-mkdirp
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/mkdirp
+│  └─ licenseFile: node_modules/mkdirp/LICENSE
+├─ ms@2.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/vercel/ms
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ms
+│  └─ licenseFile: node_modules/ms/license.md
+├─ multicast-dns@7.2.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/multicast-dns
+│  ├─ publisher: Mathias Buus
+│  ├─ url: @mafintosh
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/multicast-dns
+│  └─ licenseFile: node_modules/multicast-dns/LICENSE
+├─ mz@2.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/normalize/mz
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/mz
+│  └─ licenseFile: node_modules/mz/LICENSE
+├─ nanoid@3.3.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ai/nanoid
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/nanoid
+│  └─ licenseFile: node_modules/nanoid/LICENSE
+├─ natural-compare-lite@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/litejs/natural-compare-lite
+│  ├─ publisher: Lauri Rooden
+│  ├─ url: https://github.com/litejs/natural-compare-lite
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/natural-compare-lite
+│  └─ licenseFile: node_modules/natural-compare-lite/README.md
+├─ natural-compare@1.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/litejs/natural-compare-lite
+│  ├─ publisher: Lauri Rooden
+│  ├─ url: https://github.com/litejs/natural-compare-lite
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/natural-compare
+│  └─ licenseFile: node_modules/natural-compare/README.md
+├─ negotiator@0.6.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/negotiator
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/negotiator
+│  └─ licenseFile: node_modules/negotiator/LICENSE
+├─ neo-async@2.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/suguru03/neo-async
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/neo-async
+│  └─ licenseFile: node_modules/neo-async/LICENSE
+├─ no-case@3.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/change-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/no-case
+│  └─ licenseFile: node_modules/no-case/LICENSE
+├─ node-fetch@2.6.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bitinn/node-fetch
+│  ├─ publisher: David Frank
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/node-fetch
+│  └─ licenseFile: node_modules/node-fetch/LICENSE.md
+├─ node-forge@1.3.1
+│  ├─ licenses: (BSD-3-Clause OR GPL-2.0)
+│  ├─ repository: https://github.com/digitalbazaar/forge
+│  ├─ publisher: Digital Bazaar, Inc.
+│  ├─ email: support@digitalbazaar.com
+│  ├─ url: http://digitalbazaar.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/node-forge
+│  └─ licenseFile: node_modules/node-forge/LICENSE
+├─ node-int64@0.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/broofa/node-int64
+│  ├─ publisher: Robert Kieffer
+│  ├─ email: robert@broofa.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/node-int64
+│  └─ licenseFile: node_modules/node-int64/LICENSE
+├─ node-releases@2.0.14
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chicoxyzzy/node-releases
+│  ├─ publisher: Sergey Rubanov
+│  ├─ email: chi187@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/node-releases
+│  └─ licenseFile: node_modules/node-releases/LICENSE
+├─ normalize-path@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/normalize-path
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/normalize-path
+│  └─ licenseFile: node_modules/normalize-path/LICENSE
+├─ normalize-range@0.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jamestalmage/normalize-range
+│  ├─ publisher: James Talmage
+│  ├─ email: james@talmage.io
+│  ├─ url: github.com/jamestalmage
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/normalize-range
+│  └─ licenseFile: node_modules/normalize-range/license
+├─ normalize-url@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/normalize-url
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/normalize-url
+│  └─ licenseFile: node_modules/normalize-url/license
+├─ npm-run-path@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/npm-run-path
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/npm-run-path
+│  └─ licenseFile: node_modules/npm-run-path/license
+├─ nth-check@2.1.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/fb55/nth-check
+│  ├─ publisher: Felix Boehm
+│  ├─ email: me@feedic.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/nth-check
+│  └─ licenseFile: node_modules/nth-check/LICENSE
+├─ nwsapi@2.2.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dperini/nwsapi
+│  ├─ publisher: Diego Perini
+│  ├─ email: diego.perini@gmail.com
+│  ├─ url: http://www.iport.it/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/nwsapi
+│  └─ licenseFile: node_modules/nwsapi/LICENSE
+├─ object-assign@4.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/object-assign
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object-assign
+│  └─ licenseFile: node_modules/object-assign/license
+├─ object-hash@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/puleos/object-hash
+│  ├─ publisher: Scott Puleo
+│  ├─ email: puleos@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object-hash
+│  └─ licenseFile: node_modules/object-hash/LICENSE
+├─ object-inspect@1.13.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/object-inspect
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object-inspect
+│  └─ licenseFile: node_modules/object-inspect/LICENSE
+├─ object-is@1.1.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/object-is
+│  ├─ publisher: Jordan Harband
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object-is
+│  └─ licenseFile: node_modules/object-is/LICENSE
+├─ object-keys@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/object-keys
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object-keys
+│  └─ licenseFile: node_modules/object-keys/LICENSE
+├─ object.assign@4.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/object.assign
+│  ├─ publisher: Jordan Harband
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object.assign
+│  └─ licenseFile: node_modules/object.assign/LICENSE
+├─ object.entries@1.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Object.entries
+│  ├─ publisher: Jordan Harband
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object.entries
+│  └─ licenseFile: node_modules/object.entries/LICENSE
+├─ object.fromentries@2.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Object.fromEntries
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object.fromentries
+│  └─ licenseFile: node_modules/object.fromentries/LICENSE
+├─ object.getownpropertydescriptors@2.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/object.getownpropertydescriptors
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object.getownpropertydescriptors
+│  └─ licenseFile: node_modules/object.getownpropertydescriptors/LICENSE
+├─ object.groupby@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Object.groupBy
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object.groupby
+│  └─ licenseFile: node_modules/object.groupby/LICENSE
+├─ object.hasown@1.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Object.hasOwn
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object.hasown
+│  └─ licenseFile: node_modules/object.hasown/LICENSE
+├─ object.values@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Object.values
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/object.values
+│  └─ licenseFile: node_modules/object.values/LICENSE
+├─ obuf@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/offset-buffer
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/obuf
+│  └─ licenseFile: node_modules/obuf/LICENSE
+├─ oidc-client-ts@3.0.1
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/authts/oidc-client-ts
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/oidc-client-ts
+│  └─ licenseFile: node_modules/oidc-client-ts/LICENSE
+├─ on-finished@2.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/on-finished
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/on-finished
+│  └─ licenseFile: node_modules/on-finished/LICENSE
+├─ on-headers@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/on-headers
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/on-headers
+│  └─ licenseFile: node_modules/on-headers/LICENSE
+├─ once@1.4.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/once
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/once
+│  └─ licenseFile: node_modules/once/LICENSE
+├─ onetime@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/onetime
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/onetime
+│  └─ licenseFile: node_modules/onetime/license
+├─ open@8.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/open
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/open
+│  └─ licenseFile: node_modules/open/license
+├─ optionator@0.9.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gkz/optionator
+│  ├─ publisher: George Zahariev
+│  ├─ email: z@georgezahariev.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/optionator
+│  └─ licenseFile: node_modules/optionator/LICENSE
+├─ os-shim@0.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/h2non/node-os-shim
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/os-shim
+│  └─ licenseFile: node_modules/os-shim/LICENSE
+├─ p-limit@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-limit
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/p-limit
+│  └─ licenseFile: node_modules/p-limit/license
+├─ p-locate@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-locate
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/p-locate
+│  └─ licenseFile: node_modules/p-locate/license
+├─ p-retry@4.6.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-retry
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/p-retry
+│  └─ licenseFile: node_modules/p-retry/license
+├─ p-try@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/p-try
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/p-try
+│  └─ licenseFile: node_modules/p-try/license
+├─ param-case@3.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/change-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/param-case
+│  └─ licenseFile: node_modules/param-case/LICENSE
+├─ parent-module@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/parent-module
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/parent-module
+│  └─ licenseFile: node_modules/parent-module/license
+├─ parse-json@5.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/parse-json
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/parse-json
+│  └─ licenseFile: node_modules/parse-json/license
+├─ parse5@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inikulin/parse5
+│  ├─ publisher: Ivan Nikulin
+│  ├─ email: ifaaan@gmail.com
+│  ├─ url: https://github.com/inikulin
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/parse5
+│  └─ licenseFile: node_modules/parse5/LICENSE
+├─ parseurl@1.3.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/parseurl
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/parseurl
+│  └─ licenseFile: node_modules/parseurl/LICENSE
+├─ pascal-case@3.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/blakeembrey/change-case
+│  ├─ publisher: Blake Embrey
+│  ├─ email: hello@blakeembrey.com
+│  ├─ url: http://blakeembrey.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pascal-case
+│  └─ licenseFile: node_modules/pascal-case/LICENSE
+├─ path-exists@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-exists
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/path-exists
+│  └─ licenseFile: node_modules/path-exists/license
+├─ path-is-absolute@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-is-absolute
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/path-is-absolute
+│  └─ licenseFile: node_modules/path-is-absolute/license
+├─ path-key@3.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-key
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/path-key
+│  └─ licenseFile: node_modules/path-key/license
+├─ path-parse@1.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jbgutierrez/path-parse
+│  ├─ publisher: Javier Blanco
+│  ├─ email: http://jbgutierrez.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/path-parse
+│  └─ licenseFile: node_modules/path-parse/LICENSE
+├─ path-scurry@1.11.1
+│  ├─ licenses: BlueOak-1.0.0
+│  ├─ repository: https://github.com/isaacs/path-scurry
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: https://blog.izs.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/path-scurry
+│  └─ licenseFile: node_modules/path-scurry/LICENSE.md
+├─ path-to-regexp@0.1.12
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/path-to-regexp
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/path-to-regexp
+│  └─ licenseFile: node_modules/path-to-regexp/LICENSE
+├─ path-type@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/path-type
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/path-type
+│  └─ licenseFile: node_modules/path-type/license
+├─ performance-now@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/braveg1rl/performance-now
+│  ├─ publisher: Braveg1rl
+│  ├─ email: braveg1rl@outlook.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/performance-now
+│  └─ licenseFile: node_modules/performance-now/license.txt
+├─ picocolors@1.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/alexeyraspopov/picocolors
+│  ├─ publisher: Alexey Raspopov
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/picocolors
+│  └─ licenseFile: node_modules/picocolors/LICENSE
+├─ picomatch@2.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/picomatch
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/picomatch
+│  └─ licenseFile: node_modules/picomatch/LICENSE
+├─ pify@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pify
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pify
+│  └─ licenseFile: node_modules/pify/license
+├─ pirates@4.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/danez/pirates
+│  ├─ publisher: Ari Porad
+│  ├─ email: ari@ariporad.com
+│  ├─ url: http://ariporad.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pirates
+│  └─ licenseFile: node_modules/pirates/LICENSE
+├─ pkg-dir@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pkg-dir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pkg-dir
+│  └─ licenseFile: node_modules/pkg-dir/license
+├─ pkg-up@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pkg-up
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pkg-up
+│  └─ licenseFile: node_modules/pkg-up/license
+├─ possible-typed-array-names@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/possible-typed-array-names
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/possible-typed-array-names
+│  └─ licenseFile: node_modules/possible-typed-array-names/LICENSE
+├─ postcss-attribute-case-insensitive@5.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-attribute-case-insensitive
+│  └─ licenseFile: node_modules/postcss-attribute-case-insensitive/LICENSE
+├─ postcss-browser-comments@4.0.0
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-browser-comments
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: csstools@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-browser-comments
+│  └─ licenseFile: node_modules/postcss-browser-comments/LICENSE.md
+├─ postcss-calc@8.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-calc
+│  ├─ publisher: Andy Jansson
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-calc
+│  └─ licenseFile: node_modules/postcss-calc/LICENSE
+├─ postcss-clamp@4.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/polemius/postcss-clamp
+│  ├─ publisher: Ivan Menshykov
+│  ├─ email: ivan.menshykov@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-clamp
+│  └─ licenseFile: node_modules/postcss-clamp/LICENSE
+├─ postcss-color-functional-notation@4.2.4
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-color-functional-notation
+│  └─ licenseFile: node_modules/postcss-color-functional-notation/LICENSE.md
+├─ postcss-color-hex-alpha@8.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-color-hex-alpha
+│  └─ licenseFile: node_modules/postcss-color-hex-alpha/LICENSE.md
+├─ postcss-color-rebeccapurple@7.1.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-color-rebeccapurple
+│  └─ licenseFile: node_modules/postcss-color-rebeccapurple/LICENSE.md
+├─ postcss-colormin@5.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-colormin
+│  └─ licenseFile: node_modules/postcss-colormin/LICENSE-MIT
+├─ postcss-convert-values@5.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-convert-values
+│  └─ licenseFile: node_modules/postcss-convert-values/LICENSE-MIT
+├─ postcss-custom-media@8.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-custom-media
+│  └─ licenseFile: node_modules/postcss-custom-media/LICENSE.md
+├─ postcss-custom-properties@12.1.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-custom-properties
+│  └─ licenseFile: node_modules/postcss-custom-properties/LICENSE.md
+├─ postcss-custom-selectors@6.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-custom-selectors
+│  └─ licenseFile: node_modules/postcss-custom-selectors/LICENSE.md
+├─ postcss-dir-pseudo-class@6.0.5
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-dir-pseudo-class
+│  └─ licenseFile: node_modules/postcss-dir-pseudo-class/LICENSE.md
+├─ postcss-discard-comments@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-discard-comments
+│  └─ licenseFile: node_modules/postcss-discard-comments/LICENSE-MIT
+├─ postcss-discard-duplicates@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-discard-duplicates
+│  └─ licenseFile: node_modules/postcss-discard-duplicates/LICENSE-MIT
+├─ postcss-discard-empty@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-discard-empty
+│  └─ licenseFile: node_modules/postcss-discard-empty/LICENSE-MIT
+├─ postcss-discard-overridden@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Justineo
+│  ├─ email: justice360@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-discard-overridden
+│  └─ licenseFile: node_modules/postcss-discard-overridden/LICENSE
+├─ postcss-double-position-gradients@3.1.2
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-double-position-gradients
+│  └─ licenseFile: node_modules/postcss-double-position-gradients/LICENSE.md
+├─ postcss-env-function@4.0.6
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-env-function
+│  └─ licenseFile: node_modules/postcss-env-function/LICENSE.md
+├─ postcss-flexbugs-fixes@5.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/luisrudge/postcss-flexbugs-fixes
+│  ├─ publisher: Luis Rudge
+│  ├─ email: luis@luisrudge.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-flexbugs-fixes
+│  └─ licenseFile: node_modules/postcss-flexbugs-fixes/LICENSE
+├─ postcss-focus-visible@6.0.4
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-focus-visible
+│  └─ licenseFile: node_modules/postcss-focus-visible/LICENSE.md
+├─ postcss-focus-within@5.0.4
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-focus-within
+│  └─ licenseFile: node_modules/postcss-focus-within/LICENSE.md
+├─ postcss-font-variant@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-font-variant
+│  ├─ publisher: Maxime Thirouin
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-font-variant
+│  └─ licenseFile: node_modules/postcss-font-variant/LICENSE
+├─ postcss-gap-properties@3.0.5
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-gap-properties
+│  └─ licenseFile: node_modules/postcss-gap-properties/LICENSE.md
+├─ postcss-image-set-function@4.0.7
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-image-set-function
+│  └─ licenseFile: node_modules/postcss-image-set-function/LICENSE.md
+├─ postcss-import@15.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-import
+│  ├─ publisher: Maxime Thirouin
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-import
+│  └─ licenseFile: node_modules/postcss-import/LICENSE
+├─ postcss-initial@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/maximkoretskiy/postcss-initial
+│  ├─ publisher: Maksim Koretskiy
+│  ├─ email: mr.green.tv@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-initial
+│  └─ licenseFile: node_modules/postcss-initial/LICENSE
+├─ postcss-js@4.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-js
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-js
+│  └─ licenseFile: node_modules/postcss-js/LICENSE
+├─ postcss-lab-function@4.2.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-lab-function
+│  └─ licenseFile: node_modules/postcss-lab-function/LICENSE.md
+├─ postcss-load-config@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-load-config
+│  ├─ publisher: Michael Ciniawky
+│  ├─ email: michael.ciniawsky@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-load-config
+│  └─ licenseFile: node_modules/postcss-load-config/LICENSE
+├─ postcss-loader@6.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/postcss-loader
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-loader
+│  └─ licenseFile: node_modules/postcss-loader/LICENSE
+├─ postcss-logical@5.0.4
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-logical
+│  └─ licenseFile: node_modules/postcss-logical/LICENSE.md
+├─ postcss-media-minmax@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-media-minmax
+│  ├─ publisher: yisi
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-media-minmax
+│  └─ licenseFile: node_modules/postcss-media-minmax/LICENSE
+├─ postcss-merge-longhand@5.1.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-merge-longhand
+│  └─ licenseFile: node_modules/postcss-merge-longhand/LICENSE-MIT
+├─ postcss-merge-rules@5.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-merge-rules
+│  └─ licenseFile: node_modules/postcss-merge-rules/LICENSE-MIT
+├─ postcss-minify-font-values@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-minify-font-values
+│  └─ licenseFile: node_modules/postcss-minify-font-values/LICENSE
+├─ postcss-minify-gradients@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-minify-gradients
+│  └─ licenseFile: node_modules/postcss-minify-gradients/LICENSE-MIT
+├─ postcss-minify-params@5.1.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-minify-params
+│  └─ licenseFile: node_modules/postcss-minify-params/LICENSE
+├─ postcss-minify-selectors@5.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-minify-selectors
+│  └─ licenseFile: node_modules/postcss-minify-selectors/LICENSE-MIT
+├─ postcss-modules-extract-imports@3.1.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/css-modules/postcss-modules-extract-imports
+│  ├─ publisher: Glen Maddern
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-modules-extract-imports
+│  └─ licenseFile: node_modules/postcss-modules-extract-imports/LICENSE
+├─ postcss-modules-local-by-default@4.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/css-modules/postcss-modules-local-by-default
+│  ├─ publisher: Mark Dalgleish
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-modules-local-by-default
+│  └─ licenseFile: node_modules/postcss-modules-local-by-default/LICENSE
+├─ postcss-modules-scope@3.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/css-modules/postcss-modules-scope
+│  ├─ publisher: Glen Maddern
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-modules-scope
+│  └─ licenseFile: node_modules/postcss-modules-scope/LICENSE
+├─ postcss-modules-values@4.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/css-modules/postcss-modules-values
+│  ├─ publisher: Glen Maddern
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-modules-values
+│  └─ licenseFile: node_modules/postcss-modules-values/LICENSE
+├─ postcss-nested@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-nested
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-nested
+│  └─ licenseFile: node_modules/postcss-nested/LICENSE
+├─ postcss-nesting@10.2.0
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-nesting
+│  └─ licenseFile: node_modules/postcss-nesting/LICENSE.md
+├─ postcss-normalize-charset@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-charset
+│  └─ licenseFile: node_modules/postcss-normalize-charset/LICENSE
+├─ postcss-normalize-display-values@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-display-values
+│  └─ licenseFile: node_modules/postcss-normalize-display-values/LICENSE-MIT
+├─ postcss-normalize-positions@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-positions
+│  └─ licenseFile: node_modules/postcss-normalize-positions/LICENSE-MIT
+├─ postcss-normalize-repeat-style@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-repeat-style
+│  └─ licenseFile: node_modules/postcss-normalize-repeat-style/LICENSE-MIT
+├─ postcss-normalize-string@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-string
+│  └─ licenseFile: node_modules/postcss-normalize-string/LICENSE-MIT
+├─ postcss-normalize-timing-functions@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-timing-functions
+│  └─ licenseFile: node_modules/postcss-normalize-timing-functions/LICENSE-MIT
+├─ postcss-normalize-unicode@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-unicode
+│  └─ licenseFile: node_modules/postcss-normalize-unicode/LICENSE-MIT
+├─ postcss-normalize-url@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-url
+│  └─ licenseFile: node_modules/postcss-normalize-url/LICENSE-MIT
+├─ postcss-normalize-whitespace@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize-whitespace
+│  └─ licenseFile: node_modules/postcss-normalize-whitespace/LICENSE-MIT
+├─ postcss-normalize@10.0.1
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-normalize
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-normalize
+│  └─ licenseFile: node_modules/postcss-normalize/LICENSE.md
+├─ postcss-opacity-percentage@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mrcgrtz/postcss-opacity-percentage
+│  ├─ publisher: Marc Görtz
+│  ├─ email: git@marcgoertz.de
+│  ├─ url: https://marcgoertz.de/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-opacity-percentage
+│  └─ licenseFile: node_modules/postcss-opacity-percentage/LICENSE.md
+├─ postcss-ordered-values@5.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-ordered-values
+│  └─ licenseFile: node_modules/postcss-ordered-values/LICENSE-MIT
+├─ postcss-overflow-shorthand@3.0.4
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-overflow-shorthand
+│  └─ licenseFile: node_modules/postcss-overflow-shorthand/LICENSE.md
+├─ postcss-page-break@3.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/shrpne/postcss-page-break
+│  ├─ publisher: shrpne
+│  ├─ email: shrpne@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-page-break
+│  └─ licenseFile: node_modules/postcss-page-break/LICENSE
+├─ postcss-place@7.0.5
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-place
+│  └─ licenseFile: node_modules/postcss-place/LICENSE.md
+├─ postcss-preset-env@7.8.3
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-preset-env
+│  └─ licenseFile: node_modules/postcss-preset-env/LICENSE.md
+├─ postcss-pseudo-class-any-link@7.1.6
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-pseudo-class-any-link
+│  └─ licenseFile: node_modules/postcss-pseudo-class-any-link/LICENSE.md
+├─ postcss-reduce-initial@5.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-reduce-initial
+│  └─ licenseFile: node_modules/postcss-reduce-initial/LICENSE-MIT
+├─ postcss-reduce-transforms@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-reduce-transforms
+│  └─ licenseFile: node_modules/postcss-reduce-transforms/LICENSE-MIT
+├─ postcss-replace-overflow-wrap@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/MattDiMu/postcss-replace-overflow-wrap
+│  ├─ publisher: Matthias Müller
+│  ├─ email: MattDiMu@users.noreply.github.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-replace-overflow-wrap
+│  └─ licenseFile: node_modules/postcss-replace-overflow-wrap/LICENSE
+├─ postcss-selector-not@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/csstools/postcss-plugins
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-selector-not
+│  └─ licenseFile: node_modules/postcss-selector-not/LICENSE
+├─ postcss-selector-parser@6.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss-selector-parser
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-selector-parser
+│  └─ licenseFile: node_modules/postcss-selector-parser/LICENSE-MIT
+├─ postcss-svgo@5.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-svgo
+│  └─ licenseFile: node_modules/postcss-svgo/LICENSE-MIT
+├─ postcss-unique-selectors@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-unique-selectors
+│  └─ licenseFile: node_modules/postcss-unique-selectors/LICENSE-MIT
+├─ postcss-value-parser@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TrySound/postcss-value-parser
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss-value-parser
+│  └─ licenseFile: node_modules/postcss-value-parser/LICENSE
+├─ postcss@8.5.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/postcss/postcss
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/postcss
+│  └─ licenseFile: node_modules/postcss/LICENSE
+├─ pre-commit@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/observing/pre-commit
+│  ├─ publisher: Arnout Kazemier
+│  ├─ email: opensource@observe.it
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pre-commit
+│  └─ licenseFile: node_modules/pre-commit/LICENSE
+├─ prelude-ls@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gkz/prelude-ls
+│  ├─ publisher: George Zahariev
+│  ├─ email: z@georgezahariev.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/prelude-ls
+│  └─ licenseFile: node_modules/prelude-ls/LICENSE
+├─ prettier@3.5.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/prettier/prettier
+│  ├─ publisher: James Long
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/prettier
+│  └─ licenseFile: node_modules/prettier/LICENSE
+├─ pretty-bytes@5.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/pretty-bytes
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pretty-bytes
+│  └─ licenseFile: node_modules/pretty-bytes/license
+├─ pretty-error@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/AriaMinaei/pretty-error
+│  ├─ publisher: Aria Minaei
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pretty-error
+│  └─ licenseFile: node_modules/pretty-error/LICENSE
+├─ pretty-format@27.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/jest
+│  ├─ publisher: James Kyle
+│  ├─ email: me@thejameskyle.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/pretty-format
+│  └─ licenseFile: node_modules/pretty-format/LICENSE
+├─ process-nextick-args@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/calvinmetcalf/process-nextick-args
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/process-nextick-args
+│  └─ licenseFile: node_modules/process-nextick-args/license.md
+├─ promise@8.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/then/promise
+│  ├─ publisher: ForbesLindesay
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/promise
+│  └─ licenseFile: node_modules/promise/LICENSE
+├─ prompts@2.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/terkelg/prompts
+│  ├─ publisher: Terkel Gjervig
+│  ├─ email: terkel@terkel.com
+│  ├─ url: https://terkel.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/prompts
+│  └─ licenseFile: node_modules/prompts/license
+├─ prop-types@15.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/prop-types
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/prop-types
+│  └─ licenseFile: node_modules/prop-types/LICENSE
+├─ proxy-addr@2.0.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/proxy-addr
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/proxy-addr
+│  └─ licenseFile: node_modules/proxy-addr/LICENSE
+├─ psl@1.9.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lupomontero/psl
+│  ├─ publisher: Lupo Montero
+│  ├─ email: lupomontero@gmail.com
+│  ├─ url: https://lupomontero.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/psl
+│  └─ licenseFile: node_modules/psl/LICENSE
+├─ punycode@2.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/punycode.js
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/punycode
+│  └─ licenseFile: node_modules/punycode/LICENSE-MIT.txt
+├─ q@1.5.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kriskowal/q
+│  ├─ publisher: Kris Kowal
+│  ├─ email: kris@cixar.com
+│  ├─ url: https://github.com/kriskowal
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/q
+│  └─ licenseFile: node_modules/q/LICENSE
+├─ qs@6.13.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/ljharb/qs
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/qs
+│  └─ licenseFile: node_modules/qs/LICENSE.md
+├─ querystringify@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/unshiftio/querystringify
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/querystringify
+│  └─ licenseFile: node_modules/querystringify/LICENSE
+├─ queue-microtask@1.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/queue-microtask
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: https://feross.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/queue-microtask
+│  └─ licenseFile: node_modules/queue-microtask/LICENSE
+├─ raf@3.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chrisdickinson/raf
+│  ├─ publisher: Chris Dickinson
+│  ├─ email: chris@neversaw.us
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/raf
+│  └─ licenseFile: node_modules/raf/LICENSE
+├─ randombytes@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/crypto-browserify/randombytes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/randombytes
+│  └─ licenseFile: node_modules/randombytes/LICENSE
+├─ range-parser@1.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/range-parser
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ url: http://tjholowaychuk.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/range-parser
+│  └─ licenseFile: node_modules/range-parser/LICENSE
+├─ raw-body@2.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stream-utils/raw-body
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/raw-body
+│  └─ licenseFile: node_modules/raw-body/LICENSE
+├─ react-app-polyfill@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/create-react-app
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-app-polyfill
+│  └─ licenseFile: node_modules/react-app-polyfill/LICENSE
+├─ react-dev-utils@12.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/create-react-app
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-dev-utils
+│  └─ licenseFile: node_modules/react-dev-utils/LICENSE
+├─ react-dom@18.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/react
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-dom
+│  └─ licenseFile: node_modules/react-dom/LICENSE
+├─ react-error-overlay@6.0.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/create-react-app
+│  ├─ publisher: Joe Haddad
+│  ├─ email: timer150@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-error-overlay
+│  └─ licenseFile: node_modules/react-error-overlay/LICENSE
+├─ react-i18next@15.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/i18next/react-i18next
+│  ├─ publisher: Jan Mühlemann
+│  ├─ email: jan.muehlemann@gmail.com
+│  ├─ url: https://github.com/jamuhl
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-i18next
+│  └─ licenseFile: node_modules/react-i18next/LICENSE
+├─ react-is@18.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/react
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-is
+│  └─ licenseFile: node_modules/react-is/LICENSE
+├─ react-oidc-context@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/authts/react-oidc-context
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-oidc-context
+│  └─ licenseFile: node_modules/react-oidc-context/LICENSE
+├─ react-refresh@0.11.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/react
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-refresh
+│  └─ licenseFile: node_modules/react-refresh/LICENSE
+├─ react-router-dom@7.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/remix-run/react-router
+│  ├─ publisher: Remix Software
+│  ├─ email: hello@remix.run
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-router-dom
+│  └─ licenseFile: node_modules/react-router-dom/LICENSE.md
+├─ react-router@7.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/remix-run/react-router
+│  ├─ publisher: Remix Software
+│  ├─ email: hello@remix.run
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-router
+│  └─ licenseFile: node_modules/react-router/LICENSE.md
+├─ react-scripts@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/create-react-app
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react-scripts
+│  └─ licenseFile: node_modules/react-scripts/LICENSE
+├─ react@18.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/react
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/react
+│  └─ licenseFile: node_modules/react/LICENSE
+├─ read-cache@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TrySound/read-cache
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/read-cache
+│  └─ licenseFile: node_modules/read-cache/LICENSE
+├─ readable-stream@2.3.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/readable-stream
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/readable-stream
+│  └─ licenseFile: node_modules/readable-stream/LICENSE
+├─ readdirp@3.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/paulmillr/readdirp
+│  ├─ publisher: Thorsten Lorenz
+│  ├─ email: thlorenz@gmx.de
+│  ├─ url: thlorenz.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/readdirp
+│  └─ licenseFile: node_modules/readdirp/LICENSE
+├─ recursive-readdir@2.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jergason/recursive-readdir
+│  ├─ publisher: Jamison Dance
+│  ├─ email: jergason@gmail.com
+│  ├─ url: http://jamison.dance.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/recursive-readdir
+│  └─ licenseFile: node_modules/recursive-readdir/LICENSE
+├─ redent@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/redent
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/redent
+│  └─ licenseFile: node_modules/redent/license
+├─ reflect.getprototypeof@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/Reflect.getPrototypeOf
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/reflect.getprototypeof
+│  └─ licenseFile: node_modules/reflect.getprototypeof/LICENSE
+├─ regenerate-unicode-properties@10.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/regenerate-unicode-properties
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/regenerate-unicode-properties
+│  └─ licenseFile: node_modules/regenerate-unicode-properties/LICENSE-MIT.txt
+├─ regenerate@1.4.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/regenerate
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/regenerate
+│  └─ licenseFile: node_modules/regenerate/LICENSE-MIT.txt
+├─ regenerator-runtime@0.13.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/regenerator/tree/main/packages/runtime
+│  ├─ publisher: Ben Newman
+│  ├─ email: bn@cs.stanford.edu
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/regenerator-runtime
+│  └─ licenseFile: node_modules/regenerator-runtime/LICENSE
+├─ regenerator-transform@0.15.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/regenerator/tree/main/packages/transform
+│  ├─ publisher: Ben Newman
+│  ├─ email: bn@cs.stanford.edu
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/regenerator-transform
+│  └─ licenseFile: node_modules/regenerator-transform/LICENSE
+├─ regex-parser@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/IonicaBizau/regex-parser.js
+│  ├─ publisher: Ionică Bizău
+│  ├─ email: bizauionica@gmail.com
+│  ├─ url: https://ionicabizau.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/regex-parser
+│  └─ licenseFile: node_modules/regex-parser/LICENSE
+├─ regexp.prototype.flags@1.5.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/RegExp.prototype.flags
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/regexp.prototype.flags
+│  └─ licenseFile: node_modules/regexp.prototype.flags/LICENSE
+├─ regexpu-core@5.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/regexpu-core
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/regexpu-core
+│  └─ licenseFile: node_modules/regexpu-core/LICENSE-MIT.txt
+├─ regjsparser@0.9.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/jviereck/regjsparser
+│  ├─ publisher: 'Julian Viereck'
+│  ├─ email: julian.viereck@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/regjsparser
+│  └─ licenseFile: node_modules/regjsparser/LICENSE.BSD
+├─ relateurl@0.2.7
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stevenvachon/relateurl
+│  ├─ publisher: Steven Vachon
+│  ├─ email: contact@svachon.com
+│  ├─ url: http://www.svachon.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/relateurl
+│  └─ licenseFile: node_modules/relateurl/license
+├─ renderkid@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/AriaMinaei/RenderKid
+│  ├─ publisher: Aria Minaei
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/renderkid
+│  └─ licenseFile: node_modules/renderkid/LICENSE
+├─ require-directory@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/troygoode/node-require-directory
+│  ├─ publisher: Troy Goode
+│  ├─ email: troygoode@gmail.com
+│  ├─ url: http://github.com/troygoode/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/require-directory
+│  └─ licenseFile: node_modules/require-directory/LICENSE
+├─ require-from-string@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/floatdrop/require-from-string
+│  ├─ publisher: Vsevolod Strukchinsky
+│  ├─ email: floatdrop@gmail.com
+│  ├─ url: github.com/floatdrop
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/require-from-string
+│  └─ licenseFile: node_modules/require-from-string/license
+├─ requires-port@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/unshiftio/requires-port
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/requires-port
+│  └─ licenseFile: node_modules/requires-port/LICENSE
+├─ resolve-cwd@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/resolve-cwd
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/resolve-cwd
+│  └─ licenseFile: node_modules/resolve-cwd/license
+├─ resolve-from@5.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/resolve-from
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/resolve-from
+│  └─ licenseFile: node_modules/resolve-from/license
+├─ resolve-url-loader@4.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/bholloway/resolve-url-loader
+│  ├─ publisher: bholloway
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/resolve-url-loader
+│  └─ licenseFile: node_modules/resolve-url-loader/LICENSE
+├─ resolve.exports@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lukeed/resolve.exports
+│  ├─ publisher: Luke Edwards
+│  ├─ email: luke.edwards05@gmail.com
+│  ├─ url: https://lukeed.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/resolve.exports
+│  └─ licenseFile: node_modules/resolve.exports/license
+├─ resolve@1.22.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserify/resolve
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/resolve
+│  └─ licenseFile: node_modules/resolve/LICENSE
+├─ retry@0.13.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tim-kos/node-retry
+│  ├─ publisher: Tim Koschützki
+│  ├─ email: tim@debuggable.com
+│  ├─ url: http://debuggable.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/retry
+│  └─ licenseFile: node_modules/retry/License
+├─ reusify@1.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mcollina/reusify
+│  ├─ publisher: Matteo Collina
+│  ├─ email: hello@matteocollina.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/reusify
+│  └─ licenseFile: node_modules/reusify/LICENSE
+├─ rimraf@3.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/rimraf
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/rimraf
+│  └─ licenseFile: node_modules/rimraf/LICENSE
+├─ rollup-plugin-terser@7.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TrySound/rollup-plugin-terser
+│  ├─ publisher: Bogdan Chadkin
+│  ├─ email: trysound@yandex.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/rollup-plugin-terser
+│  └─ licenseFile: node_modules/rollup-plugin-terser/LICENSE
+├─ rollup@2.79.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/rollup/rollup
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/rollup
+│  └─ licenseFile: node_modules/rollup/LICENSE.md
+├─ run-parallel@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/run-parallel
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: https://feross.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/run-parallel
+│  └─ licenseFile: node_modules/run-parallel/LICENSE
+├─ safe-array-concat@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/safe-array-concat
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/safe-array-concat
+│  └─ licenseFile: node_modules/safe-array-concat/LICENSE
+├─ safe-buffer@5.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/safe-buffer
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: https://feross.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/safe-buffer
+│  └─ licenseFile: node_modules/safe-buffer/LICENSE
+├─ safe-regex-test@1.0.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/safe-regex-test
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/safe-regex-test
+│  └─ licenseFile: node_modules/safe-regex-test/LICENSE
+├─ safer-buffer@2.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ChALkeR/safer-buffer
+│  ├─ publisher: Nikita Skovoroda
+│  ├─ email: chalkerx@gmail.com
+│  ├─ url: https://github.com/ChALkeR
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/safer-buffer
+│  └─ licenseFile: node_modules/safer-buffer/LICENSE
+├─ sanitize.css@13.0.0
+│  ├─ licenses: CC0-1.0
+│  ├─ repository: https://github.com/csstools/sanitize.css
+│  ├─ publisher: Jonathan Neal
+│  ├─ email: jonathantneal@hotmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/sanitize.css
+│  └─ licenseFile: node_modules/sanitize.css/LICENSE.md
+├─ sass-loader@12.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/sass-loader
+│  ├─ publisher: J. Tangelder
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/sass-loader
+│  └─ licenseFile: node_modules/sass-loader/LICENSE
+├─ sax@1.2.4
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/sax-js
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/sax
+│  └─ licenseFile: node_modules/sax/LICENSE
+├─ saxes@5.0.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/lddubeau/saxes
+│  ├─ publisher: Louis-Dominique Dubeau
+│  ├─ email: ldd@lddubeau.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/saxes
+│  └─ licenseFile: node_modules/saxes/README.md
+├─ scheduler@0.23.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/facebook/react
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/scheduler
+│  └─ licenseFile: node_modules/scheduler/LICENSE
+├─ schema-utils@4.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/schema-utils
+│  ├─ publisher: webpack Contrib
+│  ├─ url: https://github.com/webpack-contrib
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/schema-utils
+│  └─ licenseFile: node_modules/schema-utils/LICENSE
+├─ select-hose@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/select-hose
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/select-hose
+│  └─ licenseFile: node_modules/select-hose/README.md
+├─ selfsigned@2.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jfromaniello/selfsigned
+│  ├─ publisher: José F. Romaniello
+│  ├─ email: jfromaniello@gmail.com
+│  ├─ url: http://joseoncode.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/selfsigned
+│  └─ licenseFile: node_modules/selfsigned/LICENSE
+├─ semver@6.3.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/node-semver
+│  ├─ publisher: GitHub Inc.
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/semver
+│  └─ licenseFile: node_modules/semver/LICENSE
+├─ send@0.19.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pillarjs/send
+│  ├─ publisher: TJ Holowaychuk
+│  ├─ email: tj@vision-media.ca
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/send
+│  └─ licenseFile: node_modules/send/LICENSE
+├─ serialize-javascript@6.0.2
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/yahoo/serialize-javascript
+│  ├─ publisher: Eric Ferraiuolo
+│  ├─ email: edf@ericf.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/serialize-javascript
+│  └─ licenseFile: node_modules/serialize-javascript/LICENSE
+├─ serve-index@1.9.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/serve-index
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/serve-index
+│  └─ licenseFile: node_modules/serve-index/LICENSE
+├─ serve-static@1.16.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/expressjs/serve-static
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/serve-static
+│  └─ licenseFile: node_modules/serve-static/LICENSE
+├─ set-cookie-parser@2.7.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nfriedly/set-cookie-parser
+│  ├─ publisher: Nathan Friedly
+│  ├─ url: http://nfriedly.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/set-cookie-parser
+│  └─ licenseFile: node_modules/set-cookie-parser/LICENSE
+├─ set-function-length@1.2.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/set-function-length
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/set-function-length
+│  └─ licenseFile: node_modules/set-function-length/LICENSE
+├─ set-function-name@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/set-function-name
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/set-function-name
+│  └─ licenseFile: node_modules/set-function-name/LICENSE
+├─ setprototypeof@1.2.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/wesleytodd/setprototypeof
+│  ├─ publisher: Wes Todd
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/setprototypeof
+│  └─ licenseFile: node_modules/setprototypeof/LICENSE
+├─ shebang-command@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/kevva/shebang-command
+│  ├─ publisher: Kevin Mårtensson
+│  ├─ email: kevinmartensson@gmail.com
+│  ├─ url: github.com/kevva
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/shebang-command
+│  └─ licenseFile: node_modules/shebang-command/license
+├─ shebang-regex@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/shebang-regex
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/shebang-regex
+│  └─ licenseFile: node_modules/shebang-regex/license
+├─ shell-quote@1.8.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/shell-quote
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/shell-quote
+│  └─ licenseFile: node_modules/shell-quote/LICENSE
+├─ side-channel@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/side-channel
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/side-channel
+│  └─ licenseFile: node_modules/side-channel/LICENSE
+├─ signal-exit@3.0.7
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/tapjs/signal-exit
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/signal-exit
+│  └─ licenseFile: node_modules/signal-exit/LICENSE.txt
+├─ sisteransi@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/terkelg/sisteransi
+│  ├─ publisher: Terkel Gjervig
+│  ├─ email: terkel@terkel.com
+│  ├─ url: https://terkel.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/sisteransi
+│  └─ licenseFile: node_modules/sisteransi/license
+├─ slash@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/slash
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/slash
+│  └─ licenseFile: node_modules/slash/license
+├─ sockjs@0.3.24
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sockjs/sockjs-node
+│  ├─ publisher: Marek Majkowski
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/sockjs
+│  └─ licenseFile: node_modules/sockjs/LICENSE
+├─ source-list-map@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/source-list-map
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/source-list-map
+│  └─ licenseFile: node_modules/source-list-map/LICENSE
+├─ source-map-js@1.2.0
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/7rulnik/source-map-js
+│  ├─ publisher: Valentin 7rulnik Semirulnik
+│  ├─ email: v7rulnik@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/source-map-js
+│  └─ licenseFile: node_modules/source-map-js/LICENSE
+├─ source-map-loader@3.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/source-map-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/source-map-loader
+│  └─ licenseFile: node_modules/source-map-loader/LICENSE
+├─ source-map-support@0.5.21
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/evanw/node-source-map-support
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/source-map-support
+│  └─ licenseFile: node_modules/source-map-support/LICENSE.md
+├─ source-map@0.6.1
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/mozilla/source-map
+│  ├─ publisher: Nick Fitzgerald
+│  ├─ email: nfitzgerald@mozilla.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/source-map
+│  └─ licenseFile: node_modules/source-map/LICENSE
+├─ sourcemap-codec@1.4.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Rich-Harris/sourcemap-codec
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/sourcemap-codec
+│  └─ licenseFile: node_modules/sourcemap-codec/LICENSE
+├─ spawn-sync@1.0.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ForbesLindesay/spawn-sync
+│  ├─ publisher: ForbesLindesay
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/spawn-sync
+│  └─ licenseFile: node_modules/spawn-sync/LICENSE
+├─ spdy-transport@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/spdy-http2/spdy-transport
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/spdy-transport
+│  └─ licenseFile: node_modules/spdy-transport/README.md
+├─ spdy@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/node-spdy
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor.indutny@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/spdy
+│  └─ licenseFile: node_modules/spdy/README.md
+├─ sprintf-js@1.0.3
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/alexei/sprintf.js
+│  ├─ publisher: Alexandru Marasteanu
+│  ├─ email: hello@alexei.ro
+│  ├─ url: http://alexei.ro/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/sprintf-js
+│  └─ licenseFile: node_modules/sprintf-js/LICENSE
+├─ stable@0.1.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Two-Screen/stable
+│  ├─ publisher: Angry Bytes
+│  ├─ email: info@angrybytes.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/stable
+│  └─ licenseFile: node_modules/stable/README.md
+├─ stack-utils@2.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tapjs/stack-utils
+│  ├─ publisher: James Talmage
+│  ├─ email: james@talmage.io
+│  ├─ url: github.com/jamestalmage
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/stack-utils
+│  └─ licenseFile: node_modules/stack-utils/LICENSE.md
+├─ stackframe@1.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stacktracejs/stackframe
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/stackframe
+│  └─ licenseFile: node_modules/stackframe/LICENSE
+├─ static-eval@2.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/static-eval
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/static-eval
+│  └─ licenseFile: node_modules/static-eval/LICENSE
+├─ statuses@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/statuses
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/statuses
+│  └─ licenseFile: node_modules/statuses/LICENSE
+├─ stop-iteration-iterator@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/stop-iteration-iterator
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/stop-iteration-iterator
+│  └─ licenseFile: node_modules/stop-iteration-iterator/LICENSE
+├─ string-length@4.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/string-length
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/string-length
+│  └─ licenseFile: node_modules/string-length/license
+├─ string-natural-compare@3.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nwoltman/string-natural-compare
+│  ├─ publisher: Nathan Woltman
+│  ├─ email: nwoltman@outlook.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/string-natural-compare
+│  └─ licenseFile: node_modules/string-natural-compare/LICENSE.txt
+├─ string-width@4.2.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/string-width
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/string-width
+│  └─ licenseFile: node_modules/string-width/license
+├─ string.prototype.matchall@4.0.11
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/String.prototype.matchAll
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/string.prototype.matchall
+│  └─ licenseFile: node_modules/string.prototype.matchall/LICENSE
+├─ string.prototype.trim@1.2.9
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/String.prototype.trim
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/string.prototype.trim
+│  └─ licenseFile: node_modules/string.prototype.trim/LICENSE
+├─ string.prototype.trimend@1.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/String.prototype.trimEnd
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/string.prototype.trimend
+│  └─ licenseFile: node_modules/string.prototype.trimend/LICENSE
+├─ string.prototype.trimstart@1.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/es-shims/String.prototype.trimStart
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/string.prototype.trimstart
+│  └─ licenseFile: node_modules/string.prototype.trimstart/LICENSE
+├─ string_decoder@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/string_decoder
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/string_decoder
+│  └─ licenseFile: node_modules/string_decoder/LICENSE
+├─ stringify-object@3.3.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/yeoman/stringify-object
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/stringify-object
+│  └─ licenseFile: node_modules/stringify-object/LICENSE
+├─ strip-ansi@6.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/strip-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/strip-ansi
+│  └─ licenseFile: node_modules/strip-ansi/license
+├─ strip-bom@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-bom
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/strip-bom
+│  └─ licenseFile: node_modules/strip-bom/license
+├─ strip-comments@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/strip-comments
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/strip-comments
+│  └─ licenseFile: node_modules/strip-comments/LICENSE
+├─ strip-final-newline@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-final-newline
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/strip-final-newline
+│  └─ licenseFile: node_modules/strip-final-newline/license
+├─ strip-indent@3.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-indent
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/strip-indent
+│  └─ licenseFile: node_modules/strip-indent/license
+├─ strip-json-comments@3.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/strip-json-comments
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/strip-json-comments
+│  └─ licenseFile: node_modules/strip-json-comments/license
+├─ style-loader@3.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/style-loader
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/style-loader
+│  └─ licenseFile: node_modules/style-loader/LICENSE
+├─ stylehacks@5.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/cssnano/cssnano
+│  ├─ publisher: Ben Briggs
+│  ├─ email: beneb.info@gmail.com
+│  ├─ url: http://beneb.info
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/stylehacks
+│  └─ licenseFile: node_modules/stylehacks/LICENSE-MIT
+├─ sucrase@3.35.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/alangpierce/sucrase
+│  ├─ publisher: Alan Pierce
+│  ├─ email: alangpierce@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/sucrase
+│  └─ licenseFile: node_modules/sucrase/LICENSE
+├─ supports-color@7.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/supports-color
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/supports-color
+│  └─ licenseFile: node_modules/supports-color/license
+├─ supports-hyperlinks@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jamestalmage/supports-hyperlinks
+│  ├─ publisher: James Talmage
+│  ├─ email: james@talmage.io
+│  ├─ url: github.com/jamestalmage
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/supports-hyperlinks
+│  └─ licenseFile: node_modules/supports-hyperlinks/license
+├─ supports-preserve-symlinks-flag@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/node-supports-preserve-symlinks-flag
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/supports-preserve-symlinks-flag
+│  └─ licenseFile: node_modules/supports-preserve-symlinks-flag/LICENSE
+├─ svg-parser@2.0.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/Rich-Harris/svg-parser
+│  ├─ publisher: Rich Harris
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/svg-parser
+│  └─ licenseFile: node_modules/svg-parser/README.md
+├─ svgo@1.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/svg/svgo
+│  ├─ publisher: Kir Belevich
+│  ├─ email: kir@belevi.ch
+│  ├─ url: https://github.com/deepsweet
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/svgo
+│  └─ licenseFile: node_modules/svgo/LICENSE
+├─ symbol-tree@3.2.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/js-symbol-tree
+│  ├─ publisher: Joris van der Wel
+│  ├─ email: joris@jorisvanderwel.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/symbol-tree
+│  └─ licenseFile: node_modules/symbol-tree/LICENSE
+├─ tailwindcss@3.4.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/tailwindlabs/tailwindcss
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tailwindcss
+│  └─ licenseFile: node_modules/tailwindcss/LICENSE
+├─ tapable@2.2.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/tapable
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tapable
+│  └─ licenseFile: node_modules/tapable/LICENSE
+├─ temp-dir@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/temp-dir
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/temp-dir
+│  └─ licenseFile: node_modules/temp-dir/license
+├─ tempy@0.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/tempy
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tempy
+│  └─ licenseFile: node_modules/tempy/license
+├─ terminal-link@2.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/terminal-link
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/terminal-link
+│  └─ licenseFile: node_modules/terminal-link/license
+├─ terser-webpack-plugin@5.3.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack-contrib/terser-webpack-plugin
+│  ├─ publisher: webpack Contrib Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/terser-webpack-plugin
+│  └─ licenseFile: node_modules/terser-webpack-plugin/LICENSE
+├─ terser@5.31.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/terser/terser
+│  ├─ publisher: Mihai Bazon
+│  ├─ email: mihai.bazon@gmail.com
+│  ├─ url: http://lisperator.net/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/terser
+│  └─ licenseFile: node_modules/terser/LICENSE
+├─ test-exclude@6.0.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/istanbuljs/test-exclude
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/test-exclude
+│  └─ licenseFile: node_modules/test-exclude/LICENSE.txt
+├─ text-table@0.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/text-table
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/text-table
+│  └─ licenseFile: node_modules/text-table/LICENSE
+├─ thenify-all@1.6.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thenables/thenify-all
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/thenify-all
+│  └─ licenseFile: node_modules/thenify-all/LICENSE
+├─ thenify@3.3.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/thenables/thenify
+│  ├─ publisher: Jonathan Ong
+│  ├─ email: me@jongleberry.com
+│  ├─ url: http://jongleberry.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/thenify
+│  └─ licenseFile: node_modules/thenify/LICENSE
+├─ throat@6.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ForbesLindesay/throat
+│  ├─ publisher: ForbesLindesay
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/throat
+│  └─ licenseFile: node_modules/throat/LICENSE
+├─ thunky@1.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mafintosh/thunky
+│  ├─ publisher: Mathias Buus Madsen
+│  ├─ email: mathiasbuus@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/thunky
+│  └─ licenseFile: node_modules/thunky/LICENSE
+├─ tmpl@1.0.5
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/daaku/nodejs-tmpl
+│  ├─ publisher: Naitik Shah
+│  ├─ email: n@daaku.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tmpl
+│  └─ licenseFile: node_modules/tmpl/license
+├─ to-fast-properties@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/to-fast-properties
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/to-fast-properties
+│  └─ licenseFile: node_modules/to-fast-properties/license
+├─ to-regex-range@5.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/micromatch/to-regex-range
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/to-regex-range
+│  └─ licenseFile: node_modules/to-regex-range/LICENSE
+├─ toidentifier@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/component/toidentifier
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/toidentifier
+│  └─ licenseFile: node_modules/toidentifier/LICENSE
+├─ tough-cookie@4.1.4
+│  ├─ licenses: BSD-3-Clause
+│  ├─ repository: https://github.com/salesforce/tough-cookie
+│  ├─ publisher: Jeremy Stashewsky
+│  ├─ email: jstash@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tough-cookie
+│  └─ licenseFile: node_modules/tough-cookie/LICENSE
+├─ tr46@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/tr46
+│  ├─ publisher: Sebastian Mayr
+│  ├─ email: npm@smayr.name
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tr46
+│  └─ licenseFile: node_modules/tr46/LICENSE.md
+├─ tryer@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: git+https://gitlab.com/philbooth/tryer
+│  ├─ publisher: Phil Booth
+│  ├─ email: pmbooth@gmail.com
+│  ├─ url: https://philbooth.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tryer
+│  └─ licenseFile: node_modules/tryer/COPYING
+├─ ts-interface-checker@0.1.13
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/gristlabs/ts-interface-checker
+│  ├─ publisher: Dmitry S, Grist Labs
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ts-interface-checker
+│  └─ licenseFile: node_modules/ts-interface-checker/LICENSE
+├─ tsconfig-paths@3.15.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/dividab/tsconfig-paths
+│  ├─ publisher: Jonas Kello
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tsconfig-paths
+│  └─ licenseFile: node_modules/tsconfig-paths/LICENSE
+├─ tslib@2.6.3
+│  ├─ licenses: 0BSD
+│  ├─ repository: https://github.com/Microsoft/tslib
+│  ├─ publisher: Microsoft Corp.
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tslib
+│  └─ licenseFile: node_modules/tslib/LICENSE.txt
+├─ tsutils@3.21.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ajafff/tsutils
+│  ├─ publisher: Klaus Meinhardt
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/tsutils
+│  └─ licenseFile: node_modules/tsutils/LICENSE
+├─ turbo-stream@2.4.0
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/jacob-ebey/turbo-stream
+│  ├─ publisher: Jacob Ebey
+│  ├─ email: jacob.ebey@live.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/turbo-stream
+│  └─ licenseFile: node_modules/turbo-stream/LICENSE
+├─ type-check@0.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/gkz/type-check
+│  ├─ publisher: George Zahariev
+│  ├─ email: z@georgezahariev.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/type-check
+│  └─ licenseFile: node_modules/type-check/LICENSE
+├─ type-detect@4.0.8
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chaijs/type-detect
+│  ├─ publisher: Jake Luer
+│  ├─ email: jake@alogicalparadox.com
+│  ├─ url: http://alogicalparadox.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/type-detect
+│  └─ licenseFile: node_modules/type-detect/LICENSE
+├─ type-fest@0.20.2
+│  ├─ licenses: (MIT OR CC0-1.0)
+│  ├─ repository: https://github.com/sindresorhus/type-fest
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/type-fest
+│  └─ licenseFile: node_modules/type-fest/license
+├─ type-is@1.6.18
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/type-is
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/type-is
+│  └─ licenseFile: node_modules/type-is/LICENSE
+├─ typed-array-buffer@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/typed-array-buffer
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/typed-array-buffer
+│  └─ licenseFile: node_modules/typed-array-buffer/LICENSE
+├─ typed-array-byte-length@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/typed-array-byte-length
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/typed-array-byte-length
+│  └─ licenseFile: node_modules/typed-array-byte-length/LICENSE
+├─ typed-array-byte-offset@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/typed-array-byte-offset
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/typed-array-byte-offset
+│  └─ licenseFile: node_modules/typed-array-byte-offset/LICENSE
+├─ typed-array-length@1.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/typed-array-length
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/typed-array-length
+│  └─ licenseFile: node_modules/typed-array-length/LICENSE
+├─ typedarray-to-buffer@3.1.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/feross/typedarray-to-buffer
+│  ├─ publisher: Feross Aboukhadijeh
+│  ├─ email: feross@feross.org
+│  ├─ url: http://feross.org/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/typedarray-to-buffer
+│  └─ licenseFile: node_modules/typedarray-to-buffer/LICENSE
+├─ typedarray@0.0.6
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/substack/typedarray
+│  ├─ publisher: James Halliday
+│  ├─ email: mail@substack.net
+│  ├─ url: http://substack.net
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/typedarray
+│  └─ licenseFile: node_modules/typedarray/LICENSE
+├─ typescript@5.8.3
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/microsoft/TypeScript
+│  ├─ publisher: Microsoft Corp.
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/typescript
+│  └─ licenseFile: node_modules/typescript/LICENSE.txt
+├─ unbox-primitive@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/unbox-primitive
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/unbox-primitive
+│  └─ licenseFile: node_modules/unbox-primitive/LICENSE
+├─ underscore@1.12.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jashkenas/underscore
+│  ├─ publisher: Jeremy Ashkenas
+│  ├─ email: jeremy@documentcloud.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/underscore
+│  └─ licenseFile: node_modules/underscore/LICENSE
+├─ undici-types@5.26.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/nodejs/undici
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/undici-types
+│  └─ licenseFile: node_modules/undici-types/README.md
+├─ unicode-canonical-property-names-ecmascript@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/unicode-canonical-property-names-ecmascript
+│  └─ licenseFile: node_modules/unicode-canonical-property-names-ecmascript/LICENSE-MIT.txt
+├─ unicode-match-property-ecmascript@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/unicode-match-property-ecmascript
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/unicode-match-property-ecmascript
+│  └─ licenseFile: node_modules/unicode-match-property-ecmascript/LICENSE-MIT.txt
+├─ unicode-match-property-value-ecmascript@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/unicode-match-property-value-ecmascript
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/unicode-match-property-value-ecmascript
+│  └─ licenseFile: node_modules/unicode-match-property-value-ecmascript/LICENSE-MIT.txt
+├─ unicode-property-aliases-ecmascript@2.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/mathiasbynens/unicode-property-aliases-ecmascript
+│  ├─ publisher: Mathias Bynens
+│  ├─ url: https://mathiasbynens.be/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/unicode-property-aliases-ecmascript
+│  └─ licenseFile: node_modules/unicode-property-aliases-ecmascript/LICENSE-MIT.txt
+├─ unique-string@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/sindresorhus/unique-string
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/unique-string
+│  └─ licenseFile: node_modules/unique-string/license
+├─ universalify@2.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/RyanZim/universalify
+│  ├─ publisher: Ryan Zimmerman
+│  ├─ email: opensrc@ryanzim.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/universalify
+│  └─ licenseFile: node_modules/universalify/LICENSE
+├─ unpipe@1.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/stream-utils/unpipe
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/unpipe
+│  └─ licenseFile: node_modules/unpipe/LICENSE
+├─ unquote@1.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lakenen/node-unquote
+│  ├─ publisher: Cameron Lakenen
+│  ├─ email: cameron@lakenen.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/unquote
+│  └─ licenseFile: node_modules/unquote/LICENSE
+├─ upath@1.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/anodynos/upath
+│  ├─ publisher: Angelos Pikoulas
+│  ├─ email: agelos.pikoulas@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/upath
+│  └─ licenseFile: node_modules/upath/LICENSE
+├─ update-browserslist-db@1.0.16
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/browserslist/update-db
+│  ├─ publisher: Andrey Sitnik
+│  ├─ email: andrey@sitnik.ru
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/update-browserslist-db
+│  └─ licenseFile: node_modules/update-browserslist-db/LICENSE
+├─ uri-js@4.4.1
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/garycourt/uri-js
+│  ├─ publisher: Gary Court
+│  ├─ email: gary.court@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/uri-js
+│  └─ licenseFile: node_modules/uri-js/LICENSE
+├─ url-parse@1.5.10
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/unshiftio/url-parse
+│  ├─ publisher: Arnout Kazemier
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/url-parse
+│  └─ licenseFile: node_modules/url-parse/LICENSE
+├─ util-deprecate@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/TooTallNate/util-deprecate
+│  ├─ publisher: Nathan Rajlich
+│  ├─ email: nathan@tootallnate.net
+│  ├─ url: http://n8.io/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/util-deprecate
+│  └─ licenseFile: node_modules/util-deprecate/LICENSE
+├─ util.promisify@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/ljharb/util.promisify
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/util.promisify
+│  └─ licenseFile: node_modules/util.promisify/LICENSE
+├─ utila@0.4.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/AriaMinaei/utila
+│  ├─ publisher: Aria Minaei
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/utila
+│  └─ licenseFile: node_modules/utila/LICENSE
+├─ utils-merge@1.0.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jaredhanson/utils-merge
+│  ├─ publisher: Jared Hanson
+│  ├─ email: jaredhanson@gmail.com
+│  ├─ url: http://www.jaredhanson.net/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/utils-merge
+│  └─ licenseFile: node_modules/utils-merge/LICENSE
+├─ uuid@8.3.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/uuidjs/uuid
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/uuid
+│  └─ licenseFile: node_modules/uuid/LICENSE.md
+├─ v8-to-istanbul@8.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/istanbuljs/v8-to-istanbul
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/v8-to-istanbul
+│  └─ licenseFile: node_modules/v8-to-istanbul/LICENSE.txt
+├─ vary@1.1.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jshttp/vary
+│  ├─ publisher: Douglas Christopher Wilson
+│  ├─ email: doug@somethingdoug.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/vary
+│  └─ licenseFile: node_modules/vary/LICENSE
+├─ void-elements@3.1.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/pugjs/void-elements
+│  ├─ publisher: hemanth.hm
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/void-elements
+│  └─ licenseFile: node_modules/void-elements/LICENSE
+├─ w3c-hr-time@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/w3c-hr-time
+│  ├─ publisher: Timothy Gu
+│  ├─ email: timothygu99@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/w3c-hr-time
+│  └─ licenseFile: node_modules/w3c-hr-time/LICENSE.md
+├─ w3c-xmlserializer@2.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/w3c-xmlserializer
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/w3c-xmlserializer
+│  └─ licenseFile: node_modules/w3c-xmlserializer/LICENSE.md
+├─ walker@1.0.8
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/daaku/nodejs-walker
+│  ├─ publisher: Naitik Shah
+│  ├─ email: n@daaku.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/walker
+│  └─ licenseFile: node_modules/walker/LICENSE
+├─ watchpack@2.4.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/watchpack
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/watchpack
+│  └─ licenseFile: node_modules/watchpack/LICENSE
+├─ wbuf@1.7.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/indutny/wbuf
+│  ├─ publisher: Fedor Indutny
+│  ├─ email: fedor@indutny.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/wbuf
+│  └─ licenseFile: node_modules/wbuf/README.md
+├─ web-vitals@2.1.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/GoogleChrome/web-vitals
+│  ├─ publisher: Philip Walton
+│  ├─ email: philip@philipwalton.com
+│  ├─ url: http://philipwalton.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/web-vitals
+│  └─ licenseFile: node_modules/web-vitals/LICENSE
+├─ webidl-conversions@6.1.0
+│  ├─ licenses: BSD-2-Clause
+│  ├─ repository: https://github.com/jsdom/webidl-conversions
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/webidl-conversions
+│  └─ licenseFile: node_modules/webidl-conversions/LICENSE.md
+├─ webpack-dev-middleware@5.3.4
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-dev-middleware
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/webpack-dev-middleware
+│  └─ licenseFile: node_modules/webpack-dev-middleware/LICENSE
+├─ webpack-dev-server@4.15.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-dev-server
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/webpack-dev-server
+│  └─ licenseFile: node_modules/webpack-dev-server/LICENSE
+├─ webpack-manifest-plugin@4.1.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/shellscape/webpack-manifest-plugin
+│  ├─ publisher: Dane Thurber
+│  ├─ email: dane.thurber@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/webpack-manifest-plugin
+│  └─ licenseFile: node_modules/webpack-manifest-plugin/LICENSE
+├─ webpack-sources@1.4.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack-sources
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/webpack-sources
+│  └─ licenseFile: node_modules/webpack-sources/LICENSE
+├─ webpack@5.94.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/webpack/webpack
+│  ├─ publisher: Tobias Koppers @sokra
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/webpack
+│  └─ licenseFile: node_modules/webpack/LICENSE
+├─ websocket-driver@0.7.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/faye/websocket-driver-node
+│  ├─ publisher: James Coglan
+│  ├─ email: jcoglan@gmail.com
+│  ├─ url: http://jcoglan.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/websocket-driver
+│  └─ licenseFile: node_modules/websocket-driver/LICENSE.md
+├─ websocket-extensions@0.1.4
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/faye/websocket-extensions-node
+│  ├─ publisher: James Coglan
+│  ├─ email: jcoglan@gmail.com
+│  ├─ url: http://jcoglan.com/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/websocket-extensions
+│  └─ licenseFile: node_modules/websocket-extensions/LICENSE.md
+├─ whatwg-encoding@1.0.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/whatwg-encoding
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/whatwg-encoding
+│  └─ licenseFile: node_modules/whatwg-encoding/LICENSE.txt
+├─ whatwg-fetch@3.6.20
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/github/fetch
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/whatwg-fetch
+│  └─ licenseFile: node_modules/whatwg-fetch/LICENSE
+├─ whatwg-mimetype@2.3.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/whatwg-mimetype
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/whatwg-mimetype
+│  └─ licenseFile: node_modules/whatwg-mimetype/LICENSE.txt
+├─ whatwg-url@8.7.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jsdom/whatwg-url
+│  ├─ publisher: Sebastian Mayr
+│  ├─ email: github@smayr.name
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/whatwg-url
+│  └─ licenseFile: node_modules/whatwg-url/LICENSE.txt
+├─ which-boxed-primitive@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/which-boxed-primitive
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/which-boxed-primitive
+│  └─ licenseFile: node_modules/which-boxed-primitive/LICENSE
+├─ which-builtin-type@1.1.3
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/which-builtin-type
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/which-builtin-type
+│  └─ licenseFile: node_modules/which-builtin-type/LICENSE
+├─ which-collection@1.0.2
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/which-collection
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/which-collection
+│  └─ licenseFile: node_modules/which-collection/LICENSE
+├─ which-typed-array@1.1.15
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/inspect-js/which-typed-array
+│  ├─ publisher: Jordan Harband
+│  ├─ email: ljharb@gmail.com
+│  ├─ url: http://ljharb.codes
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/which-typed-array
+│  └─ licenseFile: node_modules/which-typed-array/LICENSE
+├─ which@1.2.14
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/node-which
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/which
+│  └─ licenseFile: node_modules/which/LICENSE
+├─ word-wrap@1.2.5
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/jonschlinkert/word-wrap
+│  ├─ publisher: Jon Schlinkert
+│  ├─ url: https://github.com/jonschlinkert
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/word-wrap
+│  └─ licenseFile: node_modules/word-wrap/LICENSE
+├─ workbox-background-sync@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-background-sync
+│  └─ licenseFile: node_modules/workbox-background-sync/LICENSE
+├─ workbox-broadcast-update@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-broadcast-update
+│  └─ licenseFile: node_modules/workbox-broadcast-update/LICENSE
+├─ workbox-build@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-build
+│  └─ licenseFile: node_modules/workbox-build/LICENSE
+├─ workbox-cacheable-response@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-cacheable-response
+│  └─ licenseFile: node_modules/workbox-cacheable-response/LICENSE
+├─ workbox-core@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-core
+│  └─ licenseFile: node_modules/workbox-core/LICENSE
+├─ workbox-expiration@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-expiration
+│  └─ licenseFile: node_modules/workbox-expiration/LICENSE
+├─ workbox-google-analytics@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-google-analytics
+│  └─ licenseFile: node_modules/workbox-google-analytics/LICENSE
+├─ workbox-navigation-preload@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-navigation-preload
+│  └─ licenseFile: node_modules/workbox-navigation-preload/LICENSE
+├─ workbox-precaching@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-precaching
+│  └─ licenseFile: node_modules/workbox-precaching/LICENSE
+├─ workbox-range-requests@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-range-requests
+│  └─ licenseFile: node_modules/workbox-range-requests/LICENSE
+├─ workbox-recipes@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-recipes
+│  └─ licenseFile: node_modules/workbox-recipes/LICENSE
+├─ workbox-routing@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-routing
+│  └─ licenseFile: node_modules/workbox-routing/LICENSE
+├─ workbox-strategies@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-strategies
+│  └─ licenseFile: node_modules/workbox-strategies/LICENSE
+├─ workbox-streams@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-streams
+│  └─ licenseFile: node_modules/workbox-streams/LICENSE
+├─ workbox-sw@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-sw
+│  └─ licenseFile: node_modules/workbox-sw/LICENSE
+├─ workbox-webpack-plugin@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-webpack-plugin
+│  └─ licenseFile: node_modules/workbox-webpack-plugin/LICENSE
+├─ workbox-window@6.6.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/googlechrome/workbox
+│  ├─ publisher: Google's Web DevRel Team
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/workbox-window
+│  └─ licenseFile: node_modules/workbox-window/LICENSE
+├─ wrap-ansi@7.0.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/chalk/wrap-ansi
+│  ├─ publisher: Sindre Sorhus
+│  ├─ email: sindresorhus@gmail.com
+│  ├─ url: https://sindresorhus.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/wrap-ansi
+│  └─ licenseFile: node_modules/wrap-ansi/license
+├─ wrappy@1.0.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/wrappy
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/wrappy
+│  └─ licenseFile: node_modules/wrappy/LICENSE
+├─ write-file-atomic@3.0.3
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/npm/write-file-atomic
+│  ├─ publisher: Rebecca Turner
+│  ├─ email: me@re-becca.org
+│  ├─ url: http://re-becca.org
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/write-file-atomic
+│  └─ licenseFile: node_modules/write-file-atomic/LICENSE
+├─ ws@8.17.1
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/websockets/ws
+│  ├─ publisher: Einar Otto Stangvik
+│  ├─ email: einaros@gmail.com
+│  ├─ url: http://2x.io
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/ws
+│  └─ licenseFile: node_modules/ws/LICENSE
+├─ xml-name-validator@3.0.0
+│  ├─ licenses: Apache-2.0
+│  ├─ repository: https://github.com/jsdom/xml-name-validator
+│  ├─ publisher: Domenic Denicola
+│  ├─ email: d@domenic.me
+│  ├─ url: https://domenic.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/xml-name-validator
+│  └─ licenseFile: node_modules/xml-name-validator/LICENSE.txt
+├─ xmlchars@2.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/lddubeau/xmlchars
+│  ├─ publisher: Louis-Dominique Dubeau
+│  ├─ email: ldd@lddubeau.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/xmlchars
+│  └─ licenseFile: node_modules/xmlchars/LICENSE
+├─ y18n@5.0.8
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/y18n
+│  ├─ publisher: Ben Coe
+│  ├─ email: bencoe@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/y18n
+│  └─ licenseFile: node_modules/y18n/LICENSE
+├─ yallist@3.1.1
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/isaacs/yallist
+│  ├─ publisher: Isaac Z. Schlueter
+│  ├─ email: i@izs.me
+│  ├─ url: http://blog.izs.me/
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/yallist
+│  └─ licenseFile: node_modules/yallist/LICENSE
+├─ yaml@1.10.2
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/eemeli/yaml
+│  ├─ publisher: Eemeli Aro
+│  ├─ email: eemeli@gmail.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/yaml
+│  └─ licenseFile: node_modules/yaml/LICENSE
+├─ yargs-parser@20.2.9
+│  ├─ licenses: ISC
+│  ├─ repository: https://github.com/yargs/yargs-parser
+│  ├─ publisher: Ben Coe
+│  ├─ email: ben@npmjs.com
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/yargs-parser
+│  └─ licenseFile: node_modules/yargs-parser/LICENSE.txt
+├─ yargs@16.2.0
+│  ├─ licenses: MIT
+│  ├─ repository: https://github.com/yargs/yargs
+│  ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/yargs
+│  └─ licenseFile: node_modules/yargs/LICENSE
+└─ yocto-queue@0.1.0
+   ├─ licenses: MIT
+   ├─ repository: https://github.com/sindresorhus/yocto-queue
+   ├─ publisher: Sindre Sorhus
+   ├─ email: sindresorhus@gmail.com
+   ├─ url: https://sindresorhus.com
+   ├─ path: /Users/angie/Desktop/projects/ageverification-demo/node_modules/yocto-queue
+   └─ licenseFile: node_modules/yocto-queue/license
+

--- a/package.json
+++ b/package.json
@@ -61,6 +61,24 @@
   "devDependencies": {
     "@types/react-i18next": "^8.1.0"
   },
+  "resolutions": {
+    "cookie": "^0.7.0",
+    "@babel/runtime": "^7.26.10",
+    "@babel/helpers": "^7.26.10",
+    "cross-spawn": "^7.0.5",
+    "express": "^4.21.2",
+    "postcss": "^8.4.31",
+    "nth-check": "^2.0.1"
+  },
+  "overrides": {
+    "cookie": "^0.7.0",
+    "@babel/runtime": "^7.26.10",
+    "@babel/helpers": "^7.26.10",
+    "cross-spawn": "^7.0.5",
+    "express": "^4.21.2",
+    "postcss": "^8.4.31",
+    "nth-check": "^2.0.1"
+  },
    "pre-commit": [
     "format",
     "typescript",

--- a/package.json
+++ b/package.json
@@ -24,14 +24,21 @@
     "react-oidc-context": "^3.1.0",
     "react-router-dom": "^7.3.0",
     "react-scripts": "5.0.1",
-    "typescript": "^4.4.2",
-    "web-vitals": "^2.1.0"
+    "typescript": "^5.8.3",
+    "web-vitals": "^2.1.0",
+    "prettier": "^3.5.3",
+    "pre-commit": "^1.2.2"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "typescript": "tsc --noEmit --composite false",
+    "licenses": "npx license-checker --direct --relativeLicensePath > licenses.txt && npx license-checker --direct --summary > licenses-summary.txt",
+    "audit": "./audit.sh",
+    "format": "prettier --write 'src/**/*.{ts,tsx,js,jsx}'"
+
   },
   "eslintConfig": {
     "extends": [
@@ -53,5 +60,11 @@
   },
   "devDependencies": {
     "@types/react-i18next": "^8.1.0"
-  }
+  },
+   "pre-commit": [
+    "format",
+    "typescript",
+    "audit",
+    "licenses"
+  ]
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import App from './App';
 
 test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+    render(<App />);
+    const linkElement = screen.getByText(/learn react/i);
+    expect(linkElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,40 @@
-import React from 'react'
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
-import AccessDenied from './views/AccessDenied'
-import AdultContent from './views/AdultContent'
-import VideoScreen from './views/Video'
-import HomeScreen from './views/Home'
-import { I18nextProvider } from 'react-i18next'
-import i18n from './translations/i18n'
+import React from 'react';
+import {createBrowserRouter, Navigate, RouterProvider} from 'react-router-dom';
+import AccessDenied from './views/AccessDenied';
+import AdultContent from './views/AdultContent';
+import VideoScreen from './views/Video';
+import HomeScreen from './views/Home';
+import {I18nextProvider} from 'react-i18next';
+import i18n from './translations/i18n';
 
 const App = (props: any) => {
     const router = createBrowserRouter([
         {
             path: '*',
-            element: <Navigate replace to="/" />,
+            element: <Navigate replace to="/" />
         },
         {
             path: '/',
-            element: <HomeScreen />,
+            element: <HomeScreen />
         },
         {
             path: '/denied',
-            element: <AccessDenied />,
+            element: <AccessDenied />
         },
         {
             path: '/adult',
-            element: <AdultContent />,
+            element: <AdultContent />
         },
         {
             path: '/video',
-            element: <VideoScreen />,
-        },
-    ])
+            element: <VideoScreen />
+        }
+    ]);
     return (
         <I18nextProvider i18n={i18n}>
             <RouterProvider router={router} />
         </I18nextProvider>
-    )
-}
+    );
+};
 
-export default App
+export default App;

--- a/src/assets/data.ts
+++ b/src/assets/data.ts
@@ -1,4 +1,4 @@
-import { ICarrouselProps } from '../components/Carrousel'
+import {ICarrouselProps} from '../components/Carrousel';
 
 export const CarrouselContinue: ICarrouselProps = {
     name: 'recommended',
@@ -6,30 +6,27 @@ export const CarrouselContinue: ICarrouselProps = {
         {
             id: '0',
             title: 'title_0',
-            imageBg:
-                'https://images.unsplash.com/photo-1650700669709-b88505f0c334?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-            category: 'category_0',
+            imageBg: 'https://images.unsplash.com/photo-1650700669709-b88505f0c334?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+            category: 'category_0'
         },
         {
             id: '1',
             title: 'title_1',
-            imageBg:
-                'https://assets.api.uizard.io/api/cdn/stream/10fd3315-3428-4f59-aac4-27a141e84439.png',
-            category: 'category_1',
+            imageBg: 'https://assets.api.uizard.io/api/cdn/stream/10fd3315-3428-4f59-aac4-27a141e84439.png',
+            category: 'category_1'
         },
         {
             id: '2',
             title: 'title_2',
             imageBg:
                 'https://images.unsplash.com/photo-1509631179647-0177331693ae?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wyMDUzMDJ8MHwxfHNlYXJjaHwzfHxOaWdodGxpZmUlMkMlMjBTZW5zdWFsJTJDJTIwRmFzaGlvbnxlbnwxfHx8fDE3MTgyMTMwMzl8MA&ixlib=rb-4.0.3&q=80&w=1080',
-            category: 'category_2',
+            category: 'category_2'
         },
         {
             id: '3',
             title: 'title_3',
-            imageBg:
-                'https://images.unsplash.com/photo-1588517936140-11085e6b748b?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-            category: 'category_3',
+            imageBg: 'https://images.unsplash.com/photo-1588517936140-11085e6b748b?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+            category: 'category_3'
         },
         {
             id: '4',
@@ -37,15 +34,14 @@ export const CarrouselContinue: ICarrouselProps = {
             requiredScope: 'over18',
             imageBg:
                 'https://images.unsplash.com/photo-1519306943444-3e1588e3fd23?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wyMDUzMDJ8MHwxfHNlYXJjaHwzfHxSb21hbmNlJTJDJTIwSW50aW1hdGUlMkMlMjBTdW5zZXR8ZW58MXx8fHwxNzE4MjEzMDM5fDA&ixlib=rb-4.0.3&q=80&w=1080',
-            category: 'category_4',
+            category: 'category_4'
         },
         {
             id: '5',
             title: 'title_5',
             requiredScope: 'over18',
-            imageBg:
-                'https://images.unsplash.com/photo-1679505519389-361f7863eeda?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-            category: 'category_5',
+            imageBg: 'https://images.unsplash.com/photo-1679505519389-361f7863eeda?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+            category: 'category_5'
         },
         {
             id: '6',
@@ -54,10 +50,10 @@ export const CarrouselContinue: ICarrouselProps = {
             isLastOfList: true,
             imageBg:
                 'https://images.unsplash.com/photo-1579752515249-330bdebd2510?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wyMDUzMDJ8MHwxfHNlYXJjaHw2fHxTZW5zdWFsfGVufDF8fHx8MTcxODIxMzAzOXww&ixlib=rb-4.0.3&q=80&w=1080',
-            category: 'category_6',
-        },
-    ],
-}
+            category: 'category_6'
+        }
+    ]
+};
 
 export const CarrouselNewest: ICarrouselProps = {
     name: 'name_continue',
@@ -67,8 +63,7 @@ export const CarrouselNewest: ICarrouselProps = {
             title: 'title_7',
             isVideo: true,
             videoBottomText: 's3E3',
-            imageBg:
-                'https://images.unsplash.com/photo-1723713296730-c0ca274a222a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+            imageBg: 'https://images.unsplash.com/photo-1723713296730-c0ca274a222a?q=80&w=2127&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D'
         },
         {
             id: '8',
@@ -77,7 +72,7 @@ export const CarrouselNewest: ICarrouselProps = {
             isVideo: true,
             videoBottomText: 's1E1',
             imageBg:
-                'https://images.unsplash.com/photo-1526509569184-2fe126e71cd3?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wyMDUzMDJ8MHwxfHNlYXJjaHwzfHxTZW5zdWFsJTJDJTIwU2VkdWN0aXZlJTJDJTIwSW50aW1hdGV8ZW58MXx8fHwxNzE4MjEzMDM5fDA&ixlib=rb-4.0.3&q=80&w=1080',
+                'https://images.unsplash.com/photo-1526509569184-2fe126e71cd3?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wyMDUzMDJ8MHwxfHNlYXJjaHwzfHxTZW5zdWFsJTJDJTIwU2VkdWN0aXZlJTJDJTIwSW50aW1hdGV8ZW58MXx8fHwxNzE4MjEzMDM5fDA&ixlib=rb-4.0.3&q=80&w=1080'
         },
         {
             id: '9',
@@ -87,24 +82,20 @@ export const CarrouselNewest: ICarrouselProps = {
             videoBottomText: 's1E1',
             isLastOfList: true,
             imageBg:
-                'https://images.unsplash.com/photo-1612490566683-0b3ceabea435?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wyMDUzMDJ8MHwxfHNlYXJjaHw2fHxQYXNzaW9uJTJDJTIwUm9tYW5jZSUyQyUyMFNlbnN1YWxpdHl8ZW58MXx8fHwxNzE4MjEzMDM5fDA&ixlib=rb-4.0.3&q=80&w=1080',
-        },
-    ],
-}
+                'https://images.unsplash.com/photo-1612490566683-0b3ceabea435?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3wyMDUzMDJ8MHwxfHNlYXJjaHw2fHxQYXNzaW9uJTJDJTIwUm9tYW5jZSUyQyUyMFNlbnN1YWxpdHl8ZW58MXx8fHwxNzE4MjEzMDM5fDA&ixlib=rb-4.0.3&q=80&w=1080'
+        }
+    ]
+};
 
 export const scopesAndPrData = [
-    { prUData: 'legalAge', scopes: ['over18fae', 'legalAge'] },
-    { prUData: 'over16', scopes: ['over16fae', 'over16'] },
-    { prUData: 'over21', scopes: ['over21fae', 'over21'] },
-    { prUData: 'over65', scopes: ['over65fae', 'over65'] },
-]
+    {prUData: 'legalAge', scopes: ['over18fae', 'legalAge']},
+    {prUData: 'over16', scopes: ['over16fae', 'over16']},
+    {prUData: 'over21', scopes: ['over21fae', 'over21']},
+    {prUData: 'over65', scopes: ['over65fae', 'over65']}
+];
 
 export const getScopeNumber = (scope: string) => {
-    const ageScopeNumber = scope?.replace('over', '')?.replace('fae', '')
+    const ageScopeNumber = scope?.replace('over', '')?.replace('fae', '');
 
-    return ageScopeNumber === 'legalAge'
-        ? 18
-        : ageScopeNumber
-        ? parseInt(ageScopeNumber)
-        : undefined
-}
+    return ageScopeNumber === 'legalAge' ? 18 : ageScopeNumber ? parseInt(ageScopeNumber) : undefined;
+};

--- a/src/components/BaseLayout.tsx
+++ b/src/components/BaseLayout.tsx
@@ -1,21 +1,14 @@
-import React from 'react'
-import './components.css'
-import cx from 'classnames'
-import LanguageSelector from './LanguageSelector'
+import React from 'react';
+import './components.css';
+import cx from 'classnames';
+import LanguageSelector from './LanguageSelector';
 
 const BaseLayout = (props: any) => {
     return (
         <div className={cx('baseLayout')}>
             <header className="baseLayout__header">
                 <div className="baseLayout__header__left">
-                    <svg
-                        width="16"
-                        height="17"
-                        className="baseLayout__header__left__icon"
-                        viewBox="0 0 16 17"
-                        fill="none"
-                        xmlns="http://www.w3.org/2000/svg"
-                    >
+                    <svg width="16" height="17" className="baseLayout__header__left__icon" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
                         <g id="$gat-icon-play-circle">
                             <path
                                 id="Vector"
@@ -25,14 +18,7 @@ const BaseLayout = (props: any) => {
                                 strokeLinecap="round"
                                 strokeLinejoin="round"
                             />
-                            <path
-                                id="Vector_2"
-                                d="M6.66602 5.83398L10.666 8.50065L6.66602 11.1673V5.83398Z"
-                                stroke="#DC3164"
-                                strokeWidth="1.33333"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                            />
+                            <path id="Vector_2" d="M6.66602 5.83398L10.666 8.50065L6.66602 11.1673V5.83398Z" stroke="#DC3164" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round" />
                         </g>
                     </svg>
 
@@ -43,17 +29,9 @@ const BaseLayout = (props: any) => {
 
                 <LanguageSelector />
             </header>
-            <div
-                className={cx(
-                    props?.noRightPadding
-                        ? 'baseLayout__body baseLayout__body--noRightPadding'
-                        : 'baseLayout__body'
-                )}
-            >
-                {props.children}
-            </div>
+            <div className={cx(props?.noRightPadding ? 'baseLayout__body baseLayout__body--noRightPadding' : 'baseLayout__body')}>{props.children}</div>
         </div>
-    )
-}
+    );
+};
 
-export default BaseLayout
+export default BaseLayout;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,131 +1,81 @@
-import { useState } from 'react'
-import { useAuth } from 'react-oidc-context'
-import { ICard } from '../model/interfaces'
-import cx from 'classnames'
-import React from 'react'
-import './components.css'
-import { useTranslation } from 'react-i18next'
-import { Chip, LockIcon } from '@gataca/design-system/web'
+import {useState} from 'react';
+import {useAuth} from 'react-oidc-context';
+import {ICard} from '../model/interfaces';
+import cx from 'classnames';
+import React from 'react';
+import './components.css';
+import {useTranslation} from 'react-i18next';
+import {Chip, LockIcon} from '@gataca/design-system/web';
 
 const Card: React.FC<ICard> = React.memo((props: ICard) => {
-    const { t } = useTranslation()
-    const [clicked, setClicked] = useState(false)
-    const auth = useAuth()
+    const {t} = useTranslation();
+    const [clicked, setClicked] = useState(false);
+    const auth = useAuth();
 
     return (
-        <div
-            className={cx('card')}
-            key={props.title}
-            style={{ backgroundImage: `url(${props.imageBg})` }}
-            id={`card__${props.id}`}
-        >
+        <div className={cx('card')} key={props.title} style={{backgroundImage: `url(${props.imageBg})`}} id={`card__${props.id}`}>
             <div
                 className="card__content"
                 onClick={() => {
-                    setClicked(true)
+                    setClicked(true);
                     if (props.onClick) {
-                        props.onClick()
+                        props.onClick();
                     }
                 }}
             >
-                {props.title && (
-                    <div className={cx('card__content__title neutral100')}>
-                        {t(props.title)}
+                {props.title && <div className={cx('card__content__title neutral100')}>{t(props.title)}</div>}
+
+                {props?.isVideo && ((clicked && !!auth.user) || !props.requiredScopeIsDifferentFromFirst || !props.requiredScope) && (
+                    <div className="card__content__video">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="33" height="33" viewBox="0 0 33 33" className="card__content__video__icon" fill="none">
+                            <path
+                                d="M16.2493 29.8171C23.6131 29.8171 29.5827 23.8475 29.5827 16.4837C29.5827 9.11993 23.6131 3.15039 16.2493 3.15039C8.88555 3.15039 2.91602 9.11993 2.91602 16.4837C2.91602 23.8475 8.88555 29.8171 16.2493 29.8171Z"
+                                stroke="white"
+                                strokeWidth="2.66667"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <path d="M13.584 11.1504L21.584 16.4837L13.584 21.8171V11.1504Z" stroke="white" strokeWidth="2.66667" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                        <div className="card__content__video__footer">
+                            <div className="card__content__video__footer__top">
+                                <p className="card__content__video__footer__top__text">{t(props.videoBottomText)}</p>
+                                <Chip
+                                    id="card__content__video__footer__top__chip"
+                                    text={'21:04'}
+                                    containerStyle={{
+                                        width: 'fit-content'
+                                    }}
+                                />
+                            </div>
+                            <svg width="180" height="5" viewBox="0 0 180 5" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <rect x="0.0351562" y="0.519531" width="179.551" height="3.88217" rx="1.94109" fill="white" fillOpacity="0.3" />
+                                <rect x="0.0351562" y="0.519531" width="23.293" height="3.88217" rx="1.94109" fill="#DC3164" />
+                            </svg>
+                        </div>
                     </div>
                 )}
 
-                {props?.isVideo &&
-                    ((clicked && !!auth.user) ||
-                        !props.requiredScopeIsDifferentFromFirst ||
-                        !props.requiredScope) && (
-                        <div className="card__content__video">
-                            <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                width="33"
-                                height="33"
-                                viewBox="0 0 33 33"
-                                className="card__content__video__icon"
-                                fill="none"
-                            >
-                                <path
-                                    d="M16.2493 29.8171C23.6131 29.8171 29.5827 23.8475 29.5827 16.4837C29.5827 9.11993 23.6131 3.15039 16.2493 3.15039C8.88555 3.15039 2.91602 9.11993 2.91602 16.4837C2.91602 23.8475 8.88555 29.8171 16.2493 29.8171Z"
-                                    stroke="white"
-                                    strokeWidth="2.66667"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                />
-                                <path
-                                    d="M13.584 11.1504L21.584 16.4837L13.584 21.8171V11.1504Z"
-                                    stroke="white"
-                                    strokeWidth="2.66667"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                />
-                            </svg>
-                            <div className="card__content__video__footer">
-                                <div className="card__content__video__footer__top">
-                                    <p className="card__content__video__footer__top__text">
-                                        {t(props.videoBottomText)}
-                                    </p>
-                                    <Chip
-                                        id="card__content__video__footer__top__chip"
-                                        text={'21:04'}
-                                        containerStyle={{
-                                            width: 'fit-content',
-                                        }}
-                                    />
-                                </div>
-                                <svg
-                                    width="180"
-                                    height="5"
-                                    viewBox="0 0 180 5"
-                                    fill="none"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                >
-                                    <rect
-                                        x="0.0351562"
-                                        y="0.519531"
-                                        width="179.551"
-                                        height="3.88217"
-                                        rx="1.94109"
-                                        fill="white"
-                                        fillOpacity="0.3"
-                                    />
-                                    <rect
-                                        x="0.0351562"
-                                        y="0.519531"
-                                        width="23.293"
-                                        height="3.88217"
-                                        rx="1.94109"
-                                        fill="#DC3164"
-                                    />
-                                </svg>
-                            </div>
-                        </div>
-                    )}
+                {!(clicked && !!auth.user) && props.requiredScope && props.requiredScopeIsDifferentFromFirst && (
+                    <div className={cx('card__content__banner')}>
+                        <Chip
+                            text={t('requires', {
+                                age: props.requiredScopeNumber
+                            })}
+                            color="yellow"
+                            chipSize="medium"
+                            id={'card__content__banner__chip'}
+                            containerStyle={{
+                                width: 'fit-content'
+                            }}
+                        />
 
-                {!(clicked && !!auth.user) &&
-                    props.requiredScope &&
-                    props.requiredScopeIsDifferentFromFirst && (
-                        <div className={cx('card__content__banner')}>
-                            <Chip
-                                text={t('requires', {
-                                    age: props.requiredScopeNumber,
-                                })}
-                                color="yellow"
-                                chipSize="medium"
-                                id={'card__content__banner__chip'}
-                                containerStyle={{
-                                    width: 'fit-content',
-                                }}
-                            />
-
-                            <LockIcon size={'16'} id="lockIcon" />
-                        </div>
-                    )}
+                        <LockIcon size={'16'} id="lockIcon" />
+                    </div>
+                )}
             </div>
         </div>
-    )
-})
+    );
+});
 
-export default Card
+export default Card;

--- a/src/components/Carrousel.tsx
+++ b/src/components/Carrousel.tsx
@@ -1,63 +1,46 @@
-import React from 'react'
-import { useTranslation } from 'react-i18next'
-import { getScopeNumber } from '../assets/data'
-import { ICard } from '../model/interfaces'
-import Card from './Card'
-import './components.css'
+import React from 'react';
+import {useTranslation} from 'react-i18next';
+import {getScopeNumber} from '../assets/data';
+import {ICard} from '../model/interfaces';
+import Card from './Card';
+import './components.css';
 
 export type ICarrouselProps = {
-    name: string
-    cards: ICard[]
-    display?: () => void
-    displayNotRestrictedVideo?: () => void
-}
+    name: string;
+    cards: ICard[];
+    display?: () => void;
+    displayNotRestrictedVideo?: () => void;
+};
 
-const Carrousel: React.FC<ICarrouselProps> = React.memo(
-    (props: ICarrouselProps) => {
-        const { t } = useTranslation()
+const Carrousel: React.FC<ICarrouselProps> = React.memo((props: ICarrouselProps) => {
+    const {t} = useTranslation();
 
-        const primaryAgeScope = process.env.REACT_APP_PRIMARY_AGE_SCOPES
-        const primaryAgeScopeNumber =
-            (primaryAgeScope && getScopeNumber(primaryAgeScope)) || 0
+    const primaryAgeScope = process.env.REACT_APP_PRIMARY_AGE_SCOPES;
+    const primaryAgeScopeNumber = (primaryAgeScope && getScopeNumber(primaryAgeScope)) || 0;
 
-        const secondaryAgeScope = process.env.REACT_APP_VIDEO_AGE_SCOPE
-        const secondaryAgeScopeNumber =
-            (secondaryAgeScope && getScopeNumber(secondaryAgeScope)) || 0
+    const secondaryAgeScope = process.env.REACT_APP_VIDEO_AGE_SCOPE;
+    const secondaryAgeScopeNumber = (secondaryAgeScope && getScopeNumber(secondaryAgeScope)) || 0;
 
-        const secondaryAgeScopeIsDifferent =
-            !!secondaryAgeScopeNumber &&
-            primaryAgeScopeNumber !== secondaryAgeScopeNumber
+    const secondaryAgeScopeIsDifferent = !!secondaryAgeScopeNumber && primaryAgeScopeNumber !== secondaryAgeScopeNumber;
 
-        return (
-            <div className="carrousel">
-                <div className="carrousel__label heading5 neutral100">
-                    {t(props.name)}
-                </div>
-                <div className="carrousel__container">
-                    {props.cards?.map((c: ICard, index: number) => (
-                        <Card
-                            key={`card__${index}`}
-                            {...c}
-                            requiredScopeNumber={secondaryAgeScopeNumber}
-                            requiredScopeIsDifferentFromFirst={
-                                !!secondaryAgeScopeIsDifferent
-                            }
-                            onClick={() =>
-                                c.requiredScope &&
-                                secondaryAgeScopeIsDifferent &&
-                                props.display
-                                    ? props.display()
-                                    : c?.isVideo &&
-                                      props.displayNotRestrictedVideo
-                                    ? props.displayNotRestrictedVideo()
-                                    : {}
-                            }
-                        ></Card>
-                    ))}
-                </div>
+    return (
+        <div className="carrousel">
+            <div className="carrousel__label heading5 neutral100">{t(props.name)}</div>
+            <div className="carrousel__container">
+                {props.cards?.map((c: ICard, index: number) => (
+                    <Card
+                        key={`card__${index}`}
+                        {...c}
+                        requiredScopeNumber={secondaryAgeScopeNumber}
+                        requiredScopeIsDifferentFromFirst={!!secondaryAgeScopeIsDifferent}
+                        onClick={() =>
+                            c.requiredScope && secondaryAgeScopeIsDifferent && props.display ? props.display() : c?.isVideo && props.displayNotRestrictedVideo ? props.displayNotRestrictedVideo() : {}
+                        }
+                    ></Card>
+                ))}
             </div>
-        )
-    }
-)
+        </div>
+    );
+});
 
-export default Carrousel
+export default Carrousel;

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,68 +1,52 @@
-import React from 'react'
-import { useState } from 'react'
-import i18n, { initialLang } from '../translations/i18n'
-import './components.css'
+import React from 'react';
+import {useState} from 'react';
+import i18n, {initialLang} from '../translations/i18n';
+import './components.css';
 
 const languages = [
-    { code: 'en', name: 'English' },
-    { code: 'es', name: 'Español' },
-    { code: 'de', name: 'Deutsch' },
-    { code: 'fr', name: 'Français' },
-    { code: 'it', name: 'Italiano' },
-    { code: 'pt', name: 'Português' },
-]
+    {code: 'en', name: 'English'},
+    {code: 'es', name: 'Español'},
+    {code: 'de', name: 'Deutsch'},
+    {code: 'fr', name: 'Français'},
+    {code: 'it', name: 'Italiano'},
+    {code: 'pt', name: 'Português'}
+];
 
 const LanguageSelector = () => {
-    const [lang, setLang] = useState(initialLang)
+    const [lang, setLang] = useState(initialLang);
 
     const changeLanguageHandler = (e: any) => {
-        const newLang = e.target.value
-        setLang(newLang)
-        localStorage.setItem('i18nextLng', newLang)
-        i18n?.changeLanguage(newLang)
-    }
+        const newLang = e.target.value;
+        setLang(newLang);
+        localStorage.setItem('i18nextLng', newLang);
+        i18n?.changeLanguage(newLang);
+    };
 
     return (
         <div className="languageSwitcher">
-            <LanguageSwitcherSelector
-                lang={lang}
-                handleChangeLanguage={changeLanguageHandler}
-            />
+            <LanguageSwitcherSelector lang={lang} handleChangeLanguage={changeLanguageHandler} />
         </div>
-    )
-}
+    );
+};
 
 const LanguageSwitcherSelector = (props: any) => {
-    const { lang, handleChangeLanguage } = props
+    const {lang, handleChangeLanguage} = props;
     return (
         <div className="languageSelector">
-            <select
-                className="languageSelector__select buttonSM neutral100"
-                value={lang}
-                onChange={handleChangeLanguage}
-            >
+            <select className="languageSelector__select buttonSM neutral100" value={lang} onChange={handleChangeLanguage}>
                 {languages.map((language) => (
                     <option key={language.code} value={language.code}>
                         {language.name}
                     </option>
                 ))}
             </select>
-            <svg
-                className="languageSelector__angleDown"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="#ffffff"
-                version="1.1"
-                id="Capa_1"
-                width="12px"
-                height="12px"
-                viewBox="0 0 30.727 30.727"
-            >
+            <svg className="languageSelector__angleDown" xmlns="http://www.w3.org/2000/svg" fill="#ffffff" version="1.1" id="Capa_1" width="12px" height="12px" viewBox="0 0 30.727 30.727">
                 <g>
                     <path d="M29.994,10.183L15.363,24.812L0.733,10.184c-0.977-0.978-0.977-2.561,0-3.536c0.977-0.977,2.559-0.976,3.536,0   l11.095,11.093L26.461,6.647c0.977-0.976,2.559-0.976,3.535,0C30.971,7.624,30.971,9.206,29.994,10.183z" />
                 </g>
             </svg>
         </div>
-    )
-}
+    );
+};
 
-export default LanguageSelector
+export default LanguageSelector;

--- a/src/components/RestrictedModal.tsx
+++ b/src/components/RestrictedModal.tsx
@@ -1,79 +1,42 @@
-import { useTranslation } from 'react-i18next'
-import './components.css'
-import { Button } from '@gataca/design-system/web'
-import React from 'react'
+import {useTranslation} from 'react-i18next';
+import './components.css';
+import {Button} from '@gataca/design-system/web';
+import React from 'react';
 
 interface RestrictedModalProps {
-    overlay?: boolean
-    close?: () => void
+    overlay?: boolean;
+    close?: () => void;
 }
 
-const RestrictedModal: React.FC<RestrictedModalProps> = React.memo(
-    ({ overlay, close }) => {
-        const { t } = useTranslation()
+const RestrictedModal: React.FC<RestrictedModalProps> = React.memo(({overlay, close}) => {
+    const {t} = useTranslation();
 
-        return (
-            <>
-                {overlay ? (
-                    <div
-                        className="restrictedModal__overlay"
-                        onClick={close}
-                    ></div>
-                ) : null}
-                <div className="restrictedModal">
-                    {close ? (
-                        <div className="restrictedModal__close">
-                            <svg
-                                onClick={close}
-                                className="restrictedModal__close__svg"
-                                xmlns="http://www.w3.org/2000/svg"
-                                width="24"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                fill="none"
-                            >
-                                <path
-                                    d="M20 4L4 20M4 4L20 20"
-                                    stroke="#e4e4e4"
-                                    strokeWidth="2"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                />
-                            </svg>
-                        </div>
-                    ) : null}
-                    <div
-                        className="restrictedModal__image"
-                        style={{
-                            backgroundImage:
-                                'url(https://freesvg.org/img/coredump-Keepass-dock-icon.png)',
-                        }}
-                    />
-                    <div className="restrictedModal__content">
-                        <p className="heading4 neutral100 textAlignCenter ">
-                            {t('contentRestricted')}
-                        </p>
-                        <p className="bodyRegularMD neutral100 textAlignCenter marginTop5">
-                            {t('blockedDueAge')}
-                        </p>
-                        <p className="bodyRegularMD neutral100 textAlignCenter">
-                            {t('verifyToProceed')}
-                        </p>
-                        <Button
-                            color="purple"
-                            onClick={() => {}}
-                            showText
-                            id="restrictedModal__content__button"
-                            state="enable"
-                            style="fill"
-                            text={t('verifyAge')}
-                            textSize="large"
-                        />
+    return (
+        <>
+            {overlay ? <div className="restrictedModal__overlay" onClick={close}></div> : null}
+            <div className="restrictedModal">
+                {close ? (
+                    <div className="restrictedModal__close">
+                        <svg onClick={close} className="restrictedModal__close__svg" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                            <path d="M20 4L4 20M4 4L20 20" stroke="#e4e4e4" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
                     </div>
+                ) : null}
+                <div
+                    className="restrictedModal__image"
+                    style={{
+                        backgroundImage: 'url(https://freesvg.org/img/coredump-Keepass-dock-icon.png)'
+                    }}
+                />
+                <div className="restrictedModal__content">
+                    <p className="heading4 neutral100 textAlignCenter ">{t('contentRestricted')}</p>
+                    <p className="bodyRegularMD neutral100 textAlignCenter marginTop5">{t('blockedDueAge')}</p>
+                    <p className="bodyRegularMD neutral100 textAlignCenter">{t('verifyToProceed')}</p>
+                    <Button color="purple" onClick={() => {}} showText id="restrictedModal__content__button" state="enable" style="fill" text={t('verifyAge')} textSize="large" />
                 </div>
-            </>
-        )
-    }
-)
+            </div>
+        </>
+    );
+});
 
-export default RestrictedModal
+export default RestrictedModal;

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -1,16 +1,16 @@
-import React from 'react'
-import { useTranslation } from 'react-i18next'
-import './components.css'
+import React from 'react';
+import {useTranslation} from 'react-i18next';
+import './components.css';
 
 export type VideoProps = {
-    close?: () => void
-    contentUnblocked?: boolean
-    display?: boolean
-}
+    close?: () => void;
+    contentUnblocked?: boolean;
+    display?: boolean;
+};
 
 const VideoCard: React.FC<VideoProps> = React.memo((props) => {
-    const { t } = useTranslation()
-    const { close, display, contentUnblocked } = props
+    const {t} = useTranslation();
+    const {close, display, contentUnblocked} = props;
 
     return display ? (
         <>
@@ -18,38 +18,18 @@ const VideoCard: React.FC<VideoProps> = React.memo((props) => {
             <div className="videoCard">
                 {close ? (
                     <div className="videoCard__close">
-                        <svg
-                            onClick={close}
-                            className="videoCard__close__svg"
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="24"
-                            height="24"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                        >
-                            <path
-                                d="M20 4L4 20M4 4L20 20"
-                                stroke="#e4e4e4"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                            />
+                        <svg onClick={close} className="videoCard__close__svg" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                            <path d="M20 4L4 20M4 4L20 20" stroke="#e4e4e4" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
                         </svg>
                     </div>
                 ) : null}
-                {contentUnblocked ? (
-                    <p className="videoCard__text">{t('contentUnlocked')}</p>
-                ) : null}
-                <img
-                    className="videoCard__img"
-                    src="https://img.freepik.com/free-vector/video-media-player-design_114579-839.jpg"
-                    alt=""
-                />
+                {contentUnblocked ? <p className="videoCard__text">{t('contentUnlocked')}</p> : null}
+                <img className="videoCard__img" src="https://img.freepik.com/free-vector/video-media-player-design_114579-839.jpg" alt="" />
             </div>
         </>
     ) : (
         <></>
-    )
-})
+    );
+});
 
-export default VideoCard
+export default VideoCard;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,16 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import { AuthProvider } from 'react-oidc-context'
-import { oidcConfig } from './views/AdultContent'
-import App from './App'
-import reportWebVitals from './reportWebVitals'
-import { ThemeProvider } from '@gataca/design-system/web'
-import './styles/styleguide.css'
-import './styles/reset.css'
-import './styles/fonts.css'
-import './styles/globals.css'
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import {AuthProvider} from 'react-oidc-context';
+import {oidcConfig} from './views/AdultContent';
+import App from './App';
+import reportWebVitals from './reportWebVitals';
+import {ThemeProvider} from '@gataca/design-system/web';
+import './styles/styleguide.css';
+import './styles/reset.css';
+import './styles/fonts.css';
+import './styles/globals.css';
 
-const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
     <React.StrictMode>
         <AuthProvider {...oidcConfig}>
@@ -19,9 +19,9 @@ root.render(
             </ThemeProvider>
         </AuthProvider>
     </React.StrictMode>
-)
+);
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals()
+reportWebVitals();

--- a/src/model/interfaces.ts
+++ b/src/model/interfaces.ts
@@ -1,13 +1,13 @@
 export type ICard = {
-    id: string
-    title: string
-    imageBg: string
-    requiredScope?: string
-    requiredScopeNumber?: number
-    requiredScopeIsDifferentFromFirst?: boolean
-    isVideo?: boolean
-    category?: string
-    isLastOfList?: boolean
-    videoBottomText?: string
-    onClick?: () => void
-}
+    id: string;
+    title: string;
+    imageBg: string;
+    requiredScope?: string;
+    requiredScopeNumber?: number;
+    requiredScopeIsDifferentFromFirst?: boolean;
+    isVideo?: boolean;
+    category?: string;
+    isLastOfList?: boolean;
+    videoBottomText?: string;
+    onClick?: () => void;
+};

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,15 +1,15 @@
-import { ReportHandler } from 'web-vitals';
+import {ReportHandler} from 'web-vitals';
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
-  if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
-  }
+    if (onPerfEntry && onPerfEntry instanceof Function) {
+        import('web-vitals').then(({getCLS, getFID, getFCP, getLCP, getTTFB}) => {
+            getCLS(onPerfEntry);
+            getFID(onPerfEntry);
+            getFCP(onPerfEntry);
+            getLCP(onPerfEntry);
+            getTTFB(onPerfEntry);
+        });
+    }
 };
 
 export default reportWebVitals;

--- a/src/translations/i18n.tsx
+++ b/src/translations/i18n.tsx
@@ -1,21 +1,21 @@
-import i18n from 'i18next'
-import LanguageDetector from 'i18next-browser-languagedetector'
-import { initReactI18next } from 'react-i18next'
-import commonEn from './locales/en.json'
-import commonEs from './locales/es.json'
-import commonDe from './locales/de.json'
-import commonIt from './locales/it.json'
-import commonPt from './locales/pt.json'
-import commonFr from './locales/fr.json'
+import i18n from 'i18next';
+import LanguageDetector from 'i18next-browser-languagedetector';
+import {initReactI18next} from 'react-i18next';
+import commonEn from './locales/en.json';
+import commonEs from './locales/es.json';
+import commonDe from './locales/de.json';
+import commonIt from './locales/it.json';
+import commonPt from './locales/pt.json';
+import commonFr from './locales/fr.json';
 
 const resources = {
-    es: { common: commonEs },
-    en: { common: commonEn },
-    fr: { common: commonFr },
-    pt: { common: commonPt },
-    it: { common: commonIt },
-    de: { common: commonDe },
-}
+    es: {common: commonEs},
+    en: {common: commonEn},
+    fr: {common: commonFr},
+    pt: {common: commonPt},
+    it: {common: commonIt},
+    de: {common: commonDe}
+};
 
 const options = {
     order: [
@@ -23,15 +23,15 @@ const options = {
         //'cookie',
         'localStorage',
         //'sessionStorage',
-        'navigator',
+        'navigator'
         //'htmlTag',
         //'path',
         //'subdomain',
     ],
-    lookupQuerystring: 'lng',
-}
+    lookupQuerystring: 'lng'
+};
 
-const supportedLngs = ['es', 'en', 'pt', 'fr', 'de', 'it']
+const supportedLngs = ['es', 'en', 'pt', 'fr', 'de', 'it'];
 
 i18n.use(LanguageDetector)
     .use(initReactI18next)
@@ -44,21 +44,16 @@ i18n.use(LanguageDetector)
         fallbackLng: 'en',
         supportedLngs: supportedLngs,
         interpolation: {
-            escapeValue: false,
+            escapeValue: false
         },
-        debug: false,
-    })
+        debug: false
+    });
 
 // Check the localstorage saved language
-const storedLang = localStorage.getItem('i18nextLng')
-const browserLang = navigator.language.slice(0, 2)
+const storedLang = localStorage.getItem('i18nextLng');
+const browserLang = navigator.language.slice(0, 2);
 
-const initialLang =
-    storedLang && supportedLngs?.includes(storedLang)
-        ? storedLang
-        : browserLang && supportedLngs?.includes(browserLang)
-        ? browserLang
-        : 'en'
+const initialLang = storedLang && supportedLngs?.includes(storedLang) ? storedLang : browserLang && supportedLngs?.includes(browserLang) ? browserLang : 'en';
 
-export default i18n
-export { initialLang, storedLang, supportedLngs }
+export default i18n;
+export {initialLang, storedLang, supportedLngs};

--- a/src/views/AccessDenied.tsx
+++ b/src/views/AccessDenied.tsx
@@ -1,16 +1,16 @@
-import React from 'react'
-import BaseLayout from '../components/BaseLayout'
-import RestrictedModal from '../components/RestrictedModal'
-import { useTranslation } from 'react-i18next'
+import React from 'react';
+import BaseLayout from '../components/BaseLayout';
+import RestrictedModal from '../components/RestrictedModal';
+import {useTranslation} from 'react-i18next';
 
 const AccessDenied: React.FC = React.memo((props: any) => {
-    const { t } = useTranslation()
+    const {t} = useTranslation();
 
     return (
         <BaseLayout footerText={t('errorContactSupport')}>
             <RestrictedModal></RestrictedModal>
         </BaseLayout>
-    )
-})
+    );
+});
 
-export default AccessDenied
+export default AccessDenied;

--- a/src/views/AdultContent.tsx
+++ b/src/views/AdultContent.tsx
@@ -1,34 +1,30 @@
-import type { SigninPopupArgs } from 'oidc-client-ts'
-import { User } from 'oidc-client-ts'
-import { useEffect, useState } from 'react'
-import { AuthProviderProps, useAuth } from 'react-oidc-context'
-import {
-    CarrouselContinue,
-    CarrouselNewest,
-    scopesAndPrData,
-} from '../assets/data'
-import BaseLayout from '../components/BaseLayout'
-import Carrousel from '../components/Carrousel'
-import RestrictedModal from '../components/RestrictedModal'
-import VideoCard from '../components/VideoCard'
-import './views.css'
+import type {SigninPopupArgs} from 'oidc-client-ts';
+import {User} from 'oidc-client-ts';
+import {useEffect, useState} from 'react';
+import {AuthProviderProps, useAuth} from 'react-oidc-context';
+import {CarrouselContinue, CarrouselNewest, scopesAndPrData} from '../assets/data';
+import BaseLayout from '../components/BaseLayout';
+import Carrousel from '../components/Carrousel';
+import RestrictedModal from '../components/RestrictedModal';
+import VideoCard from '../components/VideoCard';
+import './views.css';
 
-import React from 'react'
-import { useTranslation } from 'react-i18next'
+import React from 'react';
+import {useTranslation} from 'react-i18next';
 
 const signinArgs: SigninPopupArgs = {
     popupWindowFeatures: {
         left: 200,
         top: 200,
         width: 400,
-        height: 400,
+        height: 400
     },
-    scope: `openid ${process.env.REACT_APP_VIDEO_AGE_SCOPE}`,
-}
+    scope: `openid ${process.env.REACT_APP_VIDEO_AGE_SCOPE}`
+};
 
 const onSigninCallback = (_user: User | void): void => {
-    window.history.replaceState({}, document.title, window.location.pathname)
-}
+    window.history.replaceState({}, document.title, window.location.pathname);
+};
 
 export const oidcConfig: AuthProviderProps = {
     authority: process.env.REACT_APP_IDP_HOST || 'https://vouch.dev.gataca.io',
@@ -38,87 +34,60 @@ export const oidcConfig: AuthProviderProps = {
     scope: `openid ${process.env.REACT_APP_VIDEO_AGE_SCOPE}`,
     response_mode: 'query',
     response_type: 'code',
-    onSigninCallback: onSigninCallback,
-}
+    onSigninCallback: onSigninCallback
+};
 
 const AdultContent: React.FC = React.memo((props: any) => {
-    const { t } = useTranslation()
-    const auth = useAuth()
+    const {t} = useTranslation();
+    const auth = useAuth();
     // console.log(JSON.stringify(auth))
-    const [display, setDisplay] = useState(false)
-    const [
-        overDifferentPrimaryAgeSelected,
-        setOverDifferentPrimaryAgeSelected,
-    ] = useState(false)
-    const [restricted, setRestricted] = useState(false)
+    const [display, setDisplay] = useState(false);
+    const [overDifferentPrimaryAgeSelected, setOverDifferentPrimaryAgeSelected] = useState(false);
+    const [restricted, setRestricted] = useState(false);
 
     useEffect(() => {
         auth.events.addUserSignedIn(() => {
             // console.log('USER SIGNED IN', auth.user)
-        })
-    })
+        });
+    });
 
-    useEffect(() => {}, [display])
+    useEffect(() => {}, [display]);
 
-    const secondaryAgeScope = process.env.REACT_APP_VIDEO_AGE_SCOPE
+    const secondaryAgeScope = process.env.REACT_APP_VIDEO_AGE_SCOPE;
 
-    const profileData = secondaryAgeScope
-        ? scopesAndPrData?.find((el) => el.scopes?.includes(secondaryAgeScope))
-              ?.prUData
-        : undefined
+    const profileData = secondaryAgeScope ? scopesAndPrData?.find((el) => el.scopes?.includes(secondaryAgeScope))?.prUData : undefined;
 
     const authAndDisplay = async () => {
         auth.signinPopup(signinArgs)
             .then((user) => {
                 // console.log('GOT USER', user)
-                if (
-                    user?.profile &&
-                    profileData &&
-                    user?.profile[profileData] === 'accepted'
-                ) {
-                    setOverDifferentPrimaryAgeSelected(true)
-                    setDisplay(true)
+                if (user?.profile && profileData && user?.profile[profileData] === 'accepted') {
+                    setOverDifferentPrimaryAgeSelected(true);
+                    setDisplay(true);
                 } else {
-                    setRestricted(true)
+                    setRestricted(true);
                 }
             })
             .catch((err) => {
                 // console.log('ERR in OIDC', err)
-            })
-    }
+            });
+    };
 
     return (
         <BaseLayout footerText={t('unleashDesires')} noRightPadding>
             <div className="view__content">
-                <Carrousel
-                    {...CarrouselContinue}
-                    display={() => authAndDisplay()}
-                ></Carrousel>
-                <Carrousel
-                    {...CarrouselNewest}
-                    display={() => authAndDisplay()}
-                    displayNotRestrictedVideo={() => setDisplay(true)}
-                ></Carrousel>
+                <Carrousel {...CarrouselContinue} display={() => authAndDisplay()}></Carrousel>
+                <Carrousel {...CarrouselNewest} display={() => authAndDisplay()} displayNotRestrictedVideo={() => setDisplay(true)}></Carrousel>
 
                 <VideoCard
                     display={display}
-                    contentUnblocked={
-                        !!(overDifferentPrimaryAgeSelected && secondaryAgeScope)
-                    }
-                    close={() => (
-                        setDisplay(false),
-                        setOverDifferentPrimaryAgeSelected(false)
-                    )}
+                    contentUnblocked={!!(overDifferentPrimaryAgeSelected && secondaryAgeScope)}
+                    close={() => (setDisplay(false), setOverDifferentPrimaryAgeSelected(false))}
                 ></VideoCard>
-                {restricted && (
-                    <RestrictedModal
-                        close={() => setRestricted(false)}
-                        overlay
-                    />
-                )}
+                {restricted && <RestrictedModal close={() => setRestricted(false)} overlay />}
             </div>
         </BaseLayout>
-    )
-})
+    );
+});
 
-export default AdultContent
+export default AdultContent;

--- a/src/views/Home.tsx
+++ b/src/views/Home.tsx
@@ -1,14 +1,14 @@
-import { Button } from '@gataca/design-system/web'
-import cx from 'classnames'
-import { Trans, useTranslation } from 'react-i18next'
-import React from 'react'
-import BaseLayout from '../components/BaseLayout'
-import { getScopeNumber } from '../assets/data'
+import {Button} from '@gataca/design-system/web';
+import cx from 'classnames';
+import {Trans, useTranslation} from 'react-i18next';
+import React from 'react';
+import BaseLayout from '../components/BaseLayout';
+import {getScopeNumber} from '../assets/data';
 
 const HomeScreen: React.FC = React.memo((props: any) => {
-    const { t } = useTranslation()
-    const primaryAgeScope = process.env.REACT_APP_PRIMARY_AGE_SCOPES
-    const ageScopeNumber = primaryAgeScope && getScopeNumber(primaryAgeScope)
+    const {t} = useTranslation();
+    const primaryAgeScope = process.env.REACT_APP_PRIMARY_AGE_SCOPES;
+    const ageScopeNumber = primaryAgeScope && getScopeNumber(primaryAgeScope);
 
     return (
         <BaseLayout>
@@ -17,45 +17,22 @@ const HomeScreen: React.FC = React.memo((props: any) => {
                     <h1 className={cx('initialView__content_title ')}>
                         {t('welcome')}
 
-                        <p
-                            className={cx(
-                                'initialView__content_title tertiary600'
-                            )}
-                        >
-                            Adult{' '}
-                            <span
-                                className={cx(
-                                    'initialView__content_title bold tertiary600'
-                                )}
-                            >
-                                Play Zone
-                            </span>
+                        <p className={cx('initialView__content_title tertiary600')}>
+                            Adult <span className={cx('initialView__content_title bold tertiary600')}>Play Zone</span>
                         </p>
                     </h1>
                     {ageScopeNumber ? (
                         <p className={cx('bodyRegularXL')}>
-                            <Trans
-                                i18nKey={'mustBeAge'}
-                                values={{ age: ageScopeNumber }}
-                            />
+                            <Trans i18nKey={'mustBeAge'} values={{age: ageScopeNumber}} />
                         </p>
                     ) : null}
                     <a href="/adult">
-                        <Button
-                            color="purple"
-                            onClick={() => {}}
-                            showText
-                            id="initialView__content__button"
-                            state="enable"
-                            style="fill"
-                            text={t('verifyAge')}
-                            textSize="medium"
-                        />
+                        <Button color="purple" onClick={() => {}} showText id="initialView__content__button" state="enable" style="fill" text={t('verifyAge')} textSize="medium" />
                     </a>
                 </div>
             </div>
         </BaseLayout>
-    )
-})
+    );
+});
 
-export default HomeScreen
+export default HomeScreen;

--- a/src/views/Video.tsx
+++ b/src/views/Video.tsx
@@ -1,38 +1,36 @@
-import { User } from 'oidc-client-ts'
-import { useEffect } from 'react'
-import { useAuth } from 'react-oidc-context'
-import BaseLayout from '../components/BaseLayout'
-import Carrousel from '../components/Carrousel'
-import VideoCard from '../components/VideoCard'
-import { CarrouselContinue, CarrouselNewest } from '../assets/data'
-import { useTranslation } from 'react-i18next'
-import React from 'react'
+import {User} from 'oidc-client-ts';
+import {useEffect} from 'react';
+import {useAuth} from 'react-oidc-context';
+import BaseLayout from '../components/BaseLayout';
+import Carrousel from '../components/Carrousel';
+import VideoCard from '../components/VideoCard';
+import {CarrouselContinue, CarrouselNewest} from '../assets/data';
+import {useTranslation} from 'react-i18next';
+import React from 'react';
 
 function getUser() {
-    const oidcStorage = localStorage.getItem(
-        `oidc.user:<your authority>:<your client id>`
-    )
+    const oidcStorage = localStorage.getItem(`oidc.user:<your authority>:<your client id>`);
     if (!oidcStorage) {
-        return null
+        return null;
     }
 
-    return User.fromStorageString(oidcStorage)
+    return User.fromStorageString(oidcStorage);
 }
 
 const VideoScreen: React.FC = React.memo((props: any) => {
-    const { t } = useTranslation()
+    const {t} = useTranslation();
 
-    const auth = useAuth()
+    const auth = useAuth();
 
     useEffect(() => {
-        let user = getUser()
+        let user = getUser();
         auth.events.addUserSignedIn(() => {
             // console.log('USER SIGNED IN', auth.user)
-        })
-    })
+        });
+    });
 
     if (auth.isLoading) {
-        let user = getUser()
+        let user = getUser();
     }
 
     if (auth.error) {
@@ -53,7 +51,7 @@ const VideoScreen: React.FC = React.memo((props: any) => {
                 <VideoCard display={true}></VideoCard>
             </div>
         </BaseLayout>
-    )
-})
+    );
+});
 
-export default VideoScreen
+export default VideoScreen;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3421,6 +3421,16 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+concat-stream@^1.4.7:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 confusing-browser-globals@^1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
@@ -3518,6 +3528,15 @@ cross-fetch@3.1.5:
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
   dependencies:
     node-fetch "2.6.7"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.6"
@@ -6627,6 +6646,14 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
   integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
 
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -7090,6 +7117,11 @@ optionator@^0.9.3:
     prelude-ls "^1.2.1"
     type-check "^0.4.0"
     word-wrap "^1.2.5"
+
+os-shim@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
+  integrity sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==
 
 p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
@@ -7826,6 +7858,15 @@ postcss@^8.3.5, postcss@^8.4.23, postcss@^8.4.33, postcss@^8.4.4:
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
 
+pre-commit@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.2.2.tgz#dbcee0ee9de7235e57f79c56d7ce94641a69eec6"
+  integrity sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==
+  dependencies:
+    cross-spawn "^5.0.1"
+    spawn-sync "^1.0.15"
+    which "1.2.x"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -7835,6 +7876,11 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
+
+prettier@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.3.tgz#4fc2ce0d657e7a02e602549f053b239cb7dfe1b5"
+  integrity sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"
@@ -7913,6 +7959,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 psl@^1.1.33:
   version "1.9.0"
@@ -8149,7 +8200,7 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
-readable-stream@^2.0.1:
+readable-stream@^2.0.1, readable-stream@^2.2.2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -8611,12 +8662,24 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  integrity sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==
+  dependencies:
+    shebang-regex "^1.0.0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+  integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -8720,6 +8783,14 @@ sourcemap-codec@^1.4.8:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+
+spawn-sync@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.15.tgz#b00799557eb7fb0c8376c29d44e8a1ea67e57476"
+  integrity sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==
+  dependencies:
+    concat-stream "^1.4.7"
+    os-shim "^0.1.2"
 
 spdy-transport@^3.0.0:
   version "3.0.0"
@@ -9352,10 +9423,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.4.2:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+  integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
+
+typescript@^5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"
@@ -9777,7 +9853,14 @@ which-typed-array@^1.1.13, which-typed-array@^1.1.14, which-typed-array@^1.1.15,
     gopd "^1.0.1"
     has-tostringtag "^1.0.2"
 
-which@^1.3.1:
+which@1.2.x:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  integrity sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -10022,6 +10105,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^3.0.2:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,6 +37,15 @@
     "@babel/highlight" "^7.24.7"
     picocolors "^1.0.0"
 
+"@babel/code-frame@^7.26.2":
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
+  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.25.9"
+    js-tokens "^4.0.0"
+    picocolors "^1.0.0"
+
 "@babel/compat-data@^7.22.6", "@babel/compat-data@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.24.7.tgz#d23bbea508c3883ba8251fb4164982c36ea577ed"
@@ -250,10 +259,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz#4d2d0f14820ede3b9807ea5fc36dfc8cd7da07f2"
   integrity sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==
 
+"@babel/helper-string-parser@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz#1aabb72ee72ed35789b4bbcad3ca2862ce614e8c"
+  integrity sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==
+
 "@babel/helper-validator-identifier@^7.24.7":
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz#75b889cfaf9e35c2aaf42cf0d72c8e91719251db"
   integrity sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==
+
+"@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
 "@babel/helper-validator-option@^7.24.7":
   version "7.24.7"
@@ -270,13 +289,13 @@
     "@babel/traverse" "^7.24.7"
     "@babel/types" "^7.24.7"
 
-"@babel/helpers@^7.24.7":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.24.7.tgz#aa2ccda29f62185acb5d42fb4a3a1b1082107416"
-  integrity sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==
+"@babel/helpers@^7.24.7", "@babel/helpers@^7.26.10":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.27.0.tgz#53d156098defa8243eab0f32fa17589075a1b808"
+  integrity sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==
   dependencies:
-    "@babel/template" "^7.24.7"
-    "@babel/types" "^7.24.7"
+    "@babel/template" "^7.27.0"
+    "@babel/types" "^7.27.0"
 
 "@babel/highlight@^7.24.7":
   version "7.24.7"
@@ -292,6 +311,13 @@
   version "7.24.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.7.tgz#9a5226f92f0c5c8ead550b750f5608e766c8ce85"
   integrity sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==
+
+"@babel/parser@^7.27.0":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.27.0.tgz#3d7d6ee268e41d2600091cbd4e145ffee85a44ec"
+  integrity sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==
+  dependencies:
+    "@babel/types" "^7.27.0"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.24.7":
   version "7.24.7"
@@ -1123,17 +1149,10 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.23.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
-  version "7.24.7"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.7.tgz#f4f0d5530e8dbdf59b3451b9b3e594b6ba082e12"
-  integrity sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==
-  dependencies:
-    regenerator-runtime "^0.14.0"
-
-"@babel/runtime@^7.17.2", "@babel/runtime@^7.19.0", "@babel/runtime@^7.25.0":
-  version "7.26.10"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
-  integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2", "@babel/runtime@^7.19.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.25.0", "@babel/runtime@^7.26.10", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
+  integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -1145,6 +1164,15 @@
     "@babel/code-frame" "^7.24.7"
     "@babel/parser" "^7.24.7"
     "@babel/types" "^7.24.7"
+
+"@babel/template@^7.27.0":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.0.tgz#b253e5406cc1df1c57dcd18f11760c2dbf40c0b4"
+  integrity sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/parser" "^7.27.0"
+    "@babel/types" "^7.27.0"
 
 "@babel/traverse@^7.24.7", "@babel/traverse@^7.7.2":
   version "7.24.7"
@@ -1170,6 +1198,14 @@
     "@babel/helper-string-parser" "^7.24.7"
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.27.0":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.27.0.tgz#ef9acb6b06c3173f6632d993ecb6d4ae470b4559"
+  integrity sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
 
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
@@ -3087,7 +3123,7 @@ bonjour-service@^1.0.11:
     fast-deep-equal "^3.1.3"
     multicast-dns "^7.2.5"
 
-boolbase@^1.0.0, boolbase@~1.0.0:
+boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
@@ -3468,15 +3504,10 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
-  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
-
-cookie@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-1.0.2.tgz#27360701532116bd3f1f9416929d176afe1e4610"
-  integrity sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==
+cookie@0.7.1, cookie@^0.7.0, cookie@^1.0.1:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 core-js-compat@^3.31.0, core-js-compat@^3.36.1:
   version "3.37.1"
@@ -3529,16 +3560,7 @@ cross-fetch@3.1.5:
   dependencies:
     node-fetch "2.6.7"
 
-cross-spawn@^5.0.1:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
-  integrity sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==
-  dependencies:
-    lru-cache "^4.0.1"
-    shebang-command "^1.2.0"
-    which "^1.2.9"
-
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^5.0.1, cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.5:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
@@ -4662,17 +4684,17 @@ expect@^29.0.0:
     jest-message-util "^29.7.0"
     jest-util "^29.7.0"
 
-express@^4.17.3:
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.21.0.tgz#d57cb706d49623d4ac27833f1cbc466b668eb915"
-  integrity sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==
+express@^4.17.3, express@^4.21.2:
+  version "4.21.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.21.2.tgz#cf250e48362174ead6cea4a566abef0162c1ec32"
+  integrity sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
     body-parser "1.20.3"
     content-disposition "0.5.4"
     content-type "~1.0.4"
-    cookie "0.6.0"
+    cookie "0.7.1"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "2.0.0"
@@ -4686,7 +4708,7 @@ express@^4.17.3:
     methods "~1.1.2"
     on-finished "2.4.1"
     parseurl "~1.3.3"
-    path-to-regexp "0.1.10"
+    path-to-regexp "0.1.12"
     proxy-addr "~2.0.7"
     qs "6.13.0"
     range-parser "~1.2.1"
@@ -6646,14 +6668,6 @@ lru-cache@^10.2.0:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.2.tgz#48206bc114c1252940c41b25b41af5b545aca878"
   integrity sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==
 
-lru-cache@^4.0.1:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
-  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
-  dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
-
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -6854,10 +6868,10 @@ mz@^2.7.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nanoid@^3.3.7:
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.9.tgz#e0097d8e026b3343ff053e9ccd407360a03f503a"
-  integrity sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==
+nanoid@^3.3.8:
+  version "3.3.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 natural-compare-lite@^1.4.0:
   version "1.4.0"
@@ -6931,14 +6945,7 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-nth-check@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
-  dependencies:
-    boolbase "~1.0.0"
-
-nth-check@^2.0.1:
+nth-check@^1.0.2, nth-check@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
   integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
@@ -7247,10 +7254,10 @@ path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
-  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
+path-to-regexp@0.1.12:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
+  integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -7262,15 +7269,15 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
-picocolors@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-0.2.1.tgz#570670f793646851d1ba135996962abad587859f"
-  integrity sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==
-
 picocolors@^1.0.0, picocolors@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
   integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.2, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
@@ -7841,22 +7848,14 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^7.0.35:
-  version "7.0.39"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
-  integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
+postcss@^7.0.35, postcss@^8.3.5, postcss@^8.4.23, postcss@^8.4.31, postcss@^8.4.33, postcss@^8.4.4:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.3.tgz#1463b6f1c7fb16fe258736cba29a2de35237eafb"
+  integrity sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==
   dependencies:
-    picocolors "^0.2.1"
-    source-map "^0.6.1"
-
-postcss@^8.3.5, postcss@^8.4.23, postcss@^8.4.33, postcss@^8.4.4:
-  version "8.4.38"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
-  integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
-  dependencies:
-    nanoid "^3.3.7"
-    picocolors "^1.0.0"
-    source-map-js "^1.2.0"
+    nanoid "^3.3.8"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 pre-commit@^1.2.2:
   version "1.2.2"
@@ -7959,11 +7958,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 psl@^1.1.33:
   version "1.9.0"
@@ -8662,24 +8656,12 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shebang-command@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
-  integrity sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==
-  dependencies:
-    shebang-regex "^1.0.0"
-
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
   integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
   dependencies:
     shebang-regex "^3.0.0"
-
-shebang-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
-  integrity sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==
 
 shebang-regex@^3.0.0:
   version "3.0.0"
@@ -8740,10 +8722,15 @@ source-list-map@^2.0.0, source-list-map@^2.0.1:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@^1.0.1, source-map-js@^1.2.0:
+source-map-js@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
+
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-loader@^3.0.0:
   version "3.0.2"
@@ -9860,7 +9847,7 @@ which@1.2.x:
   dependencies:
     isexe "^2.0.0"
 
-which@^1.2.9, which@^1.3.1:
+which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -10105,11 +10092,6 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
**DONE**
- Add format, typescript, audit and licenses to pre-commit in package.json.
- Apply prettier conf  ([commit](https://github.com/gataca-io/ageverification-demo/pull/21/commits/9e0f03f0b602b4bcb8bccb820a8e733f1c6a483f)).

**To fix pre-commit tests and Snyk vulnerabilities**

**Deleted dependencies:**
- react-stepper-horizontal.
- @testing-library/react
- json-server

**Updated dependencies:**
- typescript from "~3.8.2" to "^5.8.3"

**Installed dependencies:**
- prettier => ^3.5.3,
- pre-commit => ^1.2.2

**Forced versions:**
- @babel/runtime => 7.26.10
- @babel/helpers => 7.26.10
- cookie => 0.7.0
- cross-spawn => 7.0.5
- express => 4.21.2
- nth-check => 2.0.1
- postcss => 8.4.31

**JIRA**
[LegalAge demo: add pre-commit test related to format, typescript, audit & licenses](https://gataca.atlassian.net/browse/DEV-4776)